### PR TITLE
Fix convertToBase value of gist:_minute

### DIFF
--- a/OntologyFiles/gistTime.owl
+++ b/OntologyFiles/gistTime.owl
@@ -153,7 +153,7 @@
 	</gist:DurationUnit>
 	
 	<gist:DurationUnit rdf:about="&gist;_minute">
-		<gist:convertToBase rdf:datatype="&xs;double">1.0</gist:convertToBase>
+		<gist:convertToBase rdf:datatype="&xs;double">60.0</gist:convertToBase>
 		<gist:hasBaseUnit rdf:resource="&gist;_second"/>
 	</gist:DurationUnit>
 	


### PR DESCRIPTION
Base unit is gist:_second, conversion factor was 1.0, should be 60.0.