### PR TITLE
Fix catalog files

### DIFF
--- a/OntologyFiles/bundle-catalog-v001.xml
+++ b/OntologyFiles/bundle-catalog-v001.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<catalog prefer="public" xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
+    <uri id="User Entered Import Resolution" name="https://ontologies.semanticarts.com/o/gistAddressX.x.x" uri="gistAddressX.x.x.owl"/>
+    <uri id="User Entered Import Resolution" name="https://ontologies.semanticarts.com/o/gistAgreementX.x.x" uri="gistAgreementX.x.x.owl"/>
+    <uri id="User Entered Import Resolution" name="https://ontologies.semanticarts.com/o/gistCategoryX.x.x" uri="gistCategoryX.x.x.owl"/>
+    <uri id="User Entered Import Resolution" name="https://ontologies.semanticarts.com/o/gistContentX.x.x" uri="gistContentX.x.x.owl"/>
+    <uri id="User Entered Import Resolution" name="https://ontologies.semanticarts.com/o/gistCoreX.x.x" uri="gistCoreX.x.x.owl"/>
+    <uri id="User Entered Import Resolution" name="https://ontologies.semanticarts.com/o/gistEventX.x.x" uri="gistEventX.x.x.owl"/>
+    <uri id="User Entered Import Resolution" name="https://ontologies.semanticarts.com/o/gistIntentionX.x.x" uri="gistIntentionX.x.x.owl"/>
+    <uri id="User Entered Import Resolution" name="https://ontologies.semanticarts.com/o/gistIoTX.x.x" uri="gistIoTX.x.x.owl"/>
+    <uri id="User Entered Import Resolution" name="https://ontologies.semanticarts.com/o/gistMagnitudeX.x.x" uri="gistMagnitudeX.x.x.owl"/>
+    <uri id="User Entered Import Resolution" name="https://ontologies.semanticarts.com/o/gistMeasureX.x.x" uri="gistMeasureX.x.x.owl"/>
+    <uri id="User Entered Import Resolution" name="https://ontologies.semanticarts.com/o/gistNetworkX.x.x" uri="gistNetworkX.x.x.owl"/>
+    <uri id="User Entered Import Resolution" name="https://ontologies.semanticarts.com/o/gistOrganizationX.x.x" uri="gistOrganizationX.x.x.owl"/>
+    <uri id="User Entered Import Resolution" name="https://ontologies.semanticarts.com/o/gistPlaceX.x.x" uri="gistPlaceX.x.x.owl"/>
+    <uri id="User Entered Import Resolution" name="https://ontologies.semanticarts.com/o/gistTemporalRelationX.x.x" uri="gistTemporalRelationX.x.x.owl"/>
+    <uri id="User Entered Import Resolution" name="https://ontologies.semanticarts.com/o/gistTimeX.x.x" uri="gistTimeX.x.x.owl"/>
+    <uri id="User Entered Import Resolution" name="https://ontologies.semanticarts.com/o/gistTopX.x.x" uri="gistTopX.x.x.owl"/>
+    <uri id="User Entered Import Resolution" name="https://ontologies.semanticarts.com/o/gistUnitX.x.x" uri="gistUnitX.x.x.owl"/>
+    <uri id="User Entered Import Resolution" name="https://ontologies.semanticarts.com/o/gistUnitDimX.x.x" uri="gistUnitDimX.x.x.owl"/>
+    <uri id="User Entered Import Resolution" name="https://ontologies.semanticarts.com/o/gistWikiX.x.x" uri="gistWikiX.x.x.owl"/>
+</catalog>

--- a/OntologyFiles/catalog-v001.xml
+++ b/OntologyFiles/catalog-v001.xml
@@ -1,22 +1,22 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <catalog prefer="public" xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
-    <uri id="User Entered Import Resolution" name="https://ontologies.semanticarts.com/o/gistAddressX.x.x" uri="gistAddressX.x.x.owl"/>
-    <uri id="User Entered Import Resolution" name="https://ontologies.semanticarts.com/o/gistAgreementX.x.x" uri="gistAgreementX.x.x.owl"/>
-    <uri id="User Entered Import Resolution" name="https://ontologies.semanticarts.com/o/gistCategoryX.x.x" uri="gistCategoryX.x.x.owl"/>
-    <uri id="User Entered Import Resolution" name="https://ontologies.semanticarts.com/o/gistContentX.x.x" uri="gistContentX.x.x.owl"/>
-    <uri id="User Entered Import Resolution" name="https://ontologies.semanticarts.com/o/gistCoreX.x.x" uri="gistCoreX.x.x.owl"/>
-    <uri id="User Entered Import Resolution" name="https://ontologies.semanticarts.com/o/gistEventX.x.x" uri="gistEventX.x.x.owl"/>
-    <uri id="User Entered Import Resolution" name="https://ontologies.semanticarts.com/o/gistIntentionX.x.x" uri="gistIntentionX.x.x.owl"/>
-    <uri id="User Entered Import Resolution" name="https://ontologies.semanticarts.com/o/gistIoTX.x.x" uri="gistIoTX.x.x.owl"/>
-    <uri id="User Entered Import Resolution" name="https://ontologies.semanticarts.com/o/gistMagnitudeX.x.x" uri="gistMagnitudeX.x.x.owl"/>
-    <uri id="User Entered Import Resolution" name="https://ontologies.semanticarts.com/o/gistMeasureX.x.x" uri="gistMeasureX.x.x.owl"/>
-    <uri id="User Entered Import Resolution" name="https://ontologies.semanticarts.com/o/gistNetworkX.x.x" uri="gistNetworkX.x.x.owl"/>
-    <uri id="User Entered Import Resolution" name="https://ontologies.semanticarts.com/o/gistOrganizationX.x.x" uri="gistOrganizationX.x.x.owl"/>
-    <uri id="User Entered Import Resolution" name="https://ontologies.semanticarts.com/o/gistPlaceX.x.x" uri="gistPlaceX.x.x.owl"/>
-    <uri id="User Entered Import Resolution" name="https://ontologies.semanticarts.com/o/gistTemporalRelationX.x.x" uri="gistTemporalRelationX.x.x.owl"/>
-    <uri id="User Entered Import Resolution" name="https://ontologies.semanticarts.com/o/gistTimeX.x.x" uri="gistTimeX.x.x.owl"/>
-    <uri id="User Entered Import Resolution" name="https://ontologies.semanticarts.com/o/gistTopX.x.x" uri="gistTopX.x.x.owl"/>
-    <uri id="User Entered Import Resolution" name="https://ontologies.semanticarts.com/o/gistUnitX.x.x" uri="gistUnitX.x.x.owl"/>
-    <uri id="User Entered Import Resolution" name="https://ontologies.semanticarts.com/o/gistUnitDimX.x.x" uri="gistUnitDimX.x.x.owl"/>
-    <uri id="User Entered Import Resolution" name="https://ontologies.semanticarts.com/o/gistWikiX.x.x" uri="gistWikiX.x.x.owl"/>
+    <uri id="User Entered Import Resolution" name="https://ontologies.semanticarts.com/o/gistAddressX.x.x" uri="gistAddress.owl"/>
+    <uri id="User Entered Import Resolution" name="https://ontologies.semanticarts.com/o/gistAgreementX.x.x" uri="gistAgreement.owl"/>
+    <uri id="User Entered Import Resolution" name="https://ontologies.semanticarts.com/o/gistCategoryX.x.x" uri="gistCategory.owl"/>
+    <uri id="User Entered Import Resolution" name="https://ontologies.semanticarts.com/o/gistContentX.x.x" uri="gistContent.owl"/>
+    <uri id="User Entered Import Resolution" name="https://ontologies.semanticarts.com/o/gistCoreX.x.x" uri="gistCore.owl"/>
+    <uri id="User Entered Import Resolution" name="https://ontologies.semanticarts.com/o/gistEventX.x.x" uri="gistEvent.owl"/>
+    <uri id="User Entered Import Resolution" name="https://ontologies.semanticarts.com/o/gistIntentionX.x.x" uri="gistIntention.owl"/>
+    <uri id="User Entered Import Resolution" name="https://ontologies.semanticarts.com/o/gistIoTX.x.x" uri="gistIoT.owl"/>
+    <uri id="User Entered Import Resolution" name="https://ontologies.semanticarts.com/o/gistMagnitudeX.x.x" uri="gistMagnitude.owl"/>
+    <uri id="User Entered Import Resolution" name="https://ontologies.semanticarts.com/o/gistMeasureX.x.x" uri="gistMeasure.owl"/>
+    <uri id="User Entered Import Resolution" name="https://ontologies.semanticarts.com/o/gistNetworkX.x.x" uri="gistNetwork.owl"/>
+    <uri id="User Entered Import Resolution" name="https://ontologies.semanticarts.com/o/gistOrganizationX.x.x" uri="gistOrganization.owl"/>
+    <uri id="User Entered Import Resolution" name="https://ontologies.semanticarts.com/o/gistPlaceX.x.x" uri="gistPlace.owl"/>
+    <uri id="User Entered Import Resolution" name="https://ontologies.semanticarts.com/o/gistTemporalRelationX.x.x" uri="gistTemporalRelation.owl"/>
+    <uri id="User Entered Import Resolution" name="https://ontologies.semanticarts.com/o/gistTimeX.x.x" uri="gistTime.owl"/>
+    <uri id="User Entered Import Resolution" name="https://ontologies.semanticarts.com/o/gistTopX.x.x" uri="gistTop.owl"/>
+    <uri id="User Entered Import Resolution" name="https://ontologies.semanticarts.com/o/gistUnitX.x.x" uri="gistUnit.owl"/>
+    <uri id="User Entered Import Resolution" name="https://ontologies.semanticarts.com/o/gistUnitDimX.x.x" uri="gistUnitDim.owl"/>
+    <uri id="User Entered Import Resolution" name="https://ontologies.semanticarts.com/o/gistWikiX.x.x" uri="gistWiki.owl"/>
 </catalog>

--- a/bundle.bat
+++ b/bundle.bat
@@ -23,7 +23,7 @@ REM Inject version number into OWL file IRIs
 for %%f in (%ZIPDIR%\*.owl) do call %TOOLSDIR%\versionize %VERSION% %%f 
 
 REM Inject version number into catalog file
-copy catalog-v001.xml %ZIPDIR%
+copy bundle-catalog-v001.xml %ZIPDIR%\catalog-v001.xml
 call %TOOLSDIR%\versionize %VERSION% %ZIPDIR%\catalog-v001.xml
 
 REM Include the license file in the download
@@ -41,7 +41,7 @@ REM Create a deprecated items directory for the distribution
 set DEPDIR=%DOCDIR%\Deprecated
 mkdir %DEPDIR%
 
-REM Copy items into deprecation directory
+REM Move select items into deprecation directory
 move %ZIPDIR%\gistDeprecated*.owl %DEPDIR%
 
 pause


### PR DESCRIPTION
I noticed the catalog-v001.xml file in develop was broken in terms of being useful for when I am editing as a developer, from a git checkout.  It mapped to filenames with X.x.x in them, but our development files do not have that.  

It turns out we need 2 catalog files under source control. 
One, catalog-v001.xml, that works for developers editing from a git checkout
(that maps to non-numbered file names)
Another, bundle-catalog-v001.xml that is a template for
the catalog file provided in the web download (used by the "bundle.bat" script)

I updated the bundle.bat script and confirmed that both catalog files work for their respective purposes. 
