### PR TITLE
Remove e6Tools version info

### DIFF
--- a/OntologyFiles/gistAddress.owl
+++ b/OntologyFiles/gistAddress.owl
@@ -18,7 +18,6 @@
 		<rdfs:comment rdf:datatype="&xs;string">gistAddress</rdfs:comment>
 		<owl:imports rdf:resource="https://ontologies.semanticarts.com/o/gistPlaceX.x.x"/>
 		<owl:versionIRI rdf:resource="https://ontologies.semanticarts.com/o/gistAddressX.x.x"/>
-		<owl:versionInfo rdf:datatype="&xs;string">Created with e6Tools Graphical OWL Editor from S:\_SemanticArts\Offerings\gist\_daveGistGit\gist\gistX.x.x.vsd Page:address</owl:versionInfo>
 		<gist:license rdf:datatype="&xs;string">https://creativecommons.org/licenses/by-sa/3.0/</gist:license>
 	</owl:Ontology>
 	

--- a/OntologyFiles/gistAgreement.owl
+++ b/OntologyFiles/gistAgreement.owl
@@ -18,7 +18,6 @@
 		<rdfs:comment rdf:datatype="&xs;string">gistAgreement</rdfs:comment>
 		<owl:imports rdf:resource="https://ontologies.semanticarts.com/o/gistIntentionX.x.x"/>
 		<owl:versionIRI rdf:resource="https://ontologies.semanticarts.com/o/gistAgreementX.x.x"/>
-		<owl:versionInfo rdf:datatype="&xs;string">Created with e6Tools Graphical OWL Editor from S:\_SemanticArts\Offerings\gist\_daveGistGit\gist\gistX.x.x.vsd Page:agree</owl:versionInfo>
 		<gist:license rdf:datatype="&xs;string">https://creativecommons.org/licenses/by-sa/3.0/</gist:license>
 	</owl:Ontology>
 	

--- a/OntologyFiles/gistCategory.owl
+++ b/OntologyFiles/gistCategory.owl
@@ -18,7 +18,6 @@
 		<rdfs:comment rdf:datatype="&xs;string">gistCategory</rdfs:comment>
 		<owl:imports rdf:resource="https://ontologies.semanticarts.com/o/gistTopX.x.x"/>
 		<owl:versionIRI rdf:resource="https://ontologies.semanticarts.com/o/gistCategoryX.x.x"/>
-		<owl:versionInfo rdf:datatype="&xs;string">Created with e6Tools Graphical OWL Editor from S:\_SemanticArts\Offerings\gist\_daveGistGit\gist\gistX.x.x.vsd Page:cat</owl:versionInfo>
 		<gist:license rdf:datatype="&xs;string">https://creativecommons.org/licenses/by-sa/3.0/</gist:license>
 	</owl:Ontology>
 	

--- a/OntologyFiles/gistContent.owl
+++ b/OntologyFiles/gistContent.owl
@@ -18,7 +18,6 @@
 		<rdfs:comment rdf:datatype="&xs;string">gistContent types of content and mediums</rdfs:comment>
 		<owl:imports rdf:resource="https://ontologies.semanticarts.com/o/gistTopX.x.x"/>
 		<owl:versionIRI rdf:resource="https://ontologies.semanticarts.com/o/gistContentX.x.x"/>
-		<owl:versionInfo rdf:datatype="&xs;string">Created with e6Tools Graphical OWL Editor from S:\_SemanticArts\Offerings\gist\_daveGistGit\gist\gistX.x.x.vsd Page:content</owl:versionInfo>
 		<gist:license rdf:datatype="&xs;string">https://creativecommons.org/licenses/by-sa/3.0/</gist:license>
 	</owl:Ontology>
 	

--- a/OntologyFiles/gistCore.owl
+++ b/OntologyFiles/gistCore.owl
@@ -26,7 +26,6 @@
 		<owl:imports rdf:resource="https://ontologies.semanticarts.com/o/gistTemporalRelationX.x.x"/>
 		<owl:imports rdf:resource="https://ontologies.semanticarts.com/o/gistUnitDimX.x.x"/>
 		<owl:versionIRI rdf:resource="https://ontologies.semanticarts.com/o/gistCoreX.x.x"/>
-		<owl:versionInfo rdf:datatype="&xs;string">Created with e6Tools Graphical OWL Editor from S:\_SemanticArts\Offerings\gist\_daveGistGit\gist\gistX.x.x.vsd Page:gistCore</owl:versionInfo>
 		<gist:license rdf:datatype="&xs;string">https://creativecommons.org/licenses/by-sa/3.0/</gist:license>
 	</owl:Ontology>
 	

--- a/OntologyFiles/gistDeprecated.owl
+++ b/OntologyFiles/gistDeprecated.owl
@@ -18,7 +18,6 @@
 		<rdfs:comment rdf:datatype="&xs;string">gistDeprecated</rdfs:comment>
 		<owl:imports rdf:resource="https://ontologies.semanticarts.com/o/gistCoreX.x.x"/>
 		<owl:versionIRI rdf:resource="https://ontologies.semanticarts.com/o/gistDeprecatedX.x.x"/>
-		<owl:versionInfo rdf:datatype="&xs;string">Created with e6Tools Graphical OWL Editor from S:\_SemanticArts\Offerings\gist\_daveGistGit\gist\gistX.x.x.vsd Page:gistDeprecated</owl:versionInfo>
 	</owl:Ontology>
 	
 	<owl:AnnotationProperty rdf:about="&rdfs;comment">

--- a/OntologyFiles/gistEvent.owl
+++ b/OntologyFiles/gistEvent.owl
@@ -18,7 +18,6 @@
 		<rdfs:comment rdf:datatype="&xs;string">gistEvent introduces distinctions between planned actual and hypothetical events</rdfs:comment>
 		<owl:imports rdf:resource="https://ontologies.semanticarts.com/o/gistTimeX.x.x"/>
 		<owl:versionIRI rdf:resource="https://ontologies.semanticarts.com/o/gistEventX.x.x"/>
-		<owl:versionInfo rdf:datatype="&xs;string">Created with e6Tools Graphical OWL Editor from S:\_SemanticArts\Offerings\gist\_daveGistGit\gist\gistX.x.x.vsd Page:event</owl:versionInfo>
 		<gist:license rdf:datatype="&xs;string">https://creativecommons.org/licenses/by-sa/3.0/</gist:license>
 	</owl:Ontology>
 	

--- a/OntologyFiles/gistIntention.owl
+++ b/OntologyFiles/gistIntention.owl
@@ -18,7 +18,6 @@
 		<rdfs:comment rdf:datatype="&xs;string">gistIntention the Teleological aspect of systems.  Whey are we doing something.</rdfs:comment>
 		<owl:imports rdf:resource="https://ontologies.semanticarts.com/o/gistTopX.x.x"/>
 		<owl:versionIRI rdf:resource="https://ontologies.semanticarts.com/o/gistIntentionX.x.x"/>
-		<owl:versionInfo rdf:datatype="&xs;string">Created with e6Tools Graphical OWL Editor from S:\_SemanticArts\Offerings\gist\_daveGistGit\gist\gistX.x.x.vsd Page:intention</owl:versionInfo>
 		<gist:license rdf:datatype="&xs;string">https://creativecommons.org/licenses/by-sa/3.0/</gist:license>
 	</owl:Ontology>
 	

--- a/OntologyFiles/gistIoT.owl
+++ b/OntologyFiles/gistIoT.owl
@@ -19,7 +19,6 @@
 		<rdfs:comment rdf:datatype="&xsd;string">gistIoT</rdfs:comment>
 		<owl:imports rdf:resource="https://ontologies.semanticarts.com/o/gistNetworkX.x.x"/>
 		<owl:versionIRI rdf:resource="https://ontologies.semanticarts.com/o/gistIoTX.x.x"/>
-		<owl:versionInfo rdf:datatype="&xsd;string">Created with e6Tools Graphical OWL Editor from S:\_SemanticArts\Offerings\gist\_daveGistGit\gist\gistNetworkIoTx.x.x.vsd Page:IoT</owl:versionInfo>
 		<gist:license rdf:datatype="&xsd;string">https://creativecommons.org/licenses/by-sa/3.0/</gist:license>
 	</owl:Ontology>
 	

--- a/OntologyFiles/gistMagnitude.owl
+++ b/OntologyFiles/gistMagnitude.owl
@@ -18,7 +18,6 @@
 		<rdfs:comment rdf:datatype="&xs;string">gistMagnitude</rdfs:comment>
 		<owl:imports rdf:resource="https://ontologies.semanticarts.com/o/gistUnitX.x.x"/>
 		<owl:versionIRI rdf:resource="https://ontologies.semanticarts.com/o/gistMagnitudeX.x.x"/>
-		<owl:versionInfo rdf:datatype="&xs;string">Created with e6Tools Graphical OWL Editor from S:\_SemanticArts\Offerings\gist\_daveGistGit\gist\gistX.x.x.vsd Page:mag</owl:versionInfo>
 		<gist:license rdf:datatype="&xs;string">https://creativecommons.org/licenses/by-sa/3.0/</gist:license>
 	</owl:Ontology>
 	

--- a/OntologyFiles/gistMeasure.owl
+++ b/OntologyFiles/gistMeasure.owl
@@ -18,7 +18,6 @@
 		<rdfs:comment rdf:datatype="&xs;string">gistMeasure adds the act of measuring to magnitude</rdfs:comment>
 		<owl:imports rdf:resource="https://ontologies.semanticarts.com/o/gistEventX.x.x"/>
 		<owl:versionIRI rdf:resource="https://ontologies.semanticarts.com/o/gistMeasureX.x.x"/>
-		<owl:versionInfo rdf:datatype="&xs;string">Created with e6Tools Graphical OWL Editor from S:\_SemanticArts\Offerings\gist\_daveGistGit\gist\gistX.x.x.vsd Page:measure</owl:versionInfo>
 		<gist:license rdf:datatype="&xs;string">https://creativecommons.org/licenses/by-sa/3.0/</gist:license>
 	</owl:Ontology>
 	

--- a/OntologyFiles/gistNetwork.owl
+++ b/OntologyFiles/gistNetwork.owl
@@ -23,7 +23,6 @@
 		<owl:imports rdf:resource="https://ontologies.semanticarts.com/o/gistPlaceX.x.x"/>
 		<owl:imports rdf:resource="https://ontologies.semanticarts.com/o/gistTemporalRelationX.x.x"/>
 		<owl:versionIRI rdf:resource="https://ontologies.semanticarts.com/o/gistNetworkX.x.x"/>
-		<owl:versionInfo rdf:datatype="&xsd;string">Created with e6Tools Graphical OWL Editor from S:\_SemanticArts\Offerings\gist\_daveGistGit\gist\gistNetworkIoTx.x.x.vsd Page:Network</owl:versionInfo>
 		<gist:license rdf:datatype="&xsd;string">https://creativecommons.org/licenses/by-sa/3.0/</gist:license>
 	</owl:Ontology>
 	

--- a/OntologyFiles/gistOrganization.owl
+++ b/OntologyFiles/gistOrganization.owl
@@ -18,7 +18,6 @@
 		<rdfs:comment rdf:datatype="&xs;string">gistOrganization Government Organizations are introduced</rdfs:comment>
 		<owl:imports rdf:resource="https://ontologies.semanticarts.com/o/gistTopX.x.x"/>
 		<owl:versionIRI rdf:resource="https://ontologies.semanticarts.com/o/gistOrganizationX.x.x"/>
-		<owl:versionInfo rdf:datatype="&xs;string">Created with e6Tools Graphical OWL Editor from S:\_SemanticArts\Offerings\gist\_daveGistGit\gist\gistX.x.x.vsd Page:org</owl:versionInfo>
 		<gist:license rdf:datatype="&xs;string">https://creativecommons.org/licenses/by-sa/3.0/</gist:license>
 	</owl:Ontology>
 	

--- a/OntologyFiles/gistPlace.owl
+++ b/OntologyFiles/gistPlace.owl
@@ -18,7 +18,6 @@
 		<rdfs:comment rdf:datatype="&xs;string">gistPlace key GIS style primitives</rdfs:comment>
 		<owl:imports rdf:resource="https://ontologies.semanticarts.com/o/gistMeasureX.x.x"/>
 		<owl:versionIRI rdf:resource="https://ontologies.semanticarts.com/o/gistPlaceX.x.x"/>
-		<owl:versionInfo rdf:datatype="&xs;string">Created with e6Tools Graphical OWL Editor from S:\_SemanticArts\Offerings\gist\_daveGistGit\gist\gistX.x.x.vsd Page:place</owl:versionInfo>
 		<gist:license rdf:datatype="&xs;string">https://creativecommons.org/licenses/by-sa/3.0/</gist:license>
 	</owl:Ontology>
 	

--- a/OntologyFiles/gistTemporalRelation.owl
+++ b/OntologyFiles/gistTemporalRelation.owl
@@ -18,7 +18,6 @@
 		<rdfs:comment rdf:datatype="&xs;string">gistTemporalRelation</rdfs:comment>
 		<owl:imports rdf:resource="https://ontologies.semanticarts.com/o/gistTimeX.x.x"/>
 		<owl:versionIRI rdf:resource="https://ontologies.semanticarts.com/o/gistTemporalRelationX.x.x"/>
-		<owl:versionInfo rdf:datatype="&xs;string">Created with e6Tools Graphical OWL Editor from S:\_SemanticArts\Offerings\gist\_daveGistGit\gist\gistX.x.x.vsd Page:TR</owl:versionInfo>
 		<gist:license rdf:datatype="&xs;string">https://creativecommons.org/licenses/by-sa/3.0/</gist:license>
 	</owl:Ontology>
 	

--- a/OntologyFiles/gistTime.owl
+++ b/OntologyFiles/gistTime.owl
@@ -18,7 +18,6 @@
 		<rdfs:comment rdf:datatype="&xs;string">gistTime how timezones and some common precisions are modeled</rdfs:comment>
 		<owl:imports rdf:resource="https://ontologies.semanticarts.com/o/gistTopX.x.x"/>
 		<owl:versionIRI rdf:resource="https://ontologies.semanticarts.com/o/gistTimeX.x.x"/>
-		<owl:versionInfo rdf:datatype="&xs;string">Created with e6Tools Graphical OWL Editor from S:\_SemanticArts\Offerings\gist\_daveGistGit\gist\gistX.x.x.vsd Page:time</owl:versionInfo>
 		<gist:license rdf:datatype="&xs;string">https://creativecommons.org/licenses/by-sa/3.0/</gist:license>
 	</owl:Ontology>
 	

--- a/OntologyFiles/gistTop.owl
+++ b/OntologyFiles/gistTop.owl
@@ -18,7 +18,6 @@
 		<rdfs:comment rdf:datatype="&xsd;string">All the high level gist classes and key relastionships.  Most disjoints are declared at this level</rdfs:comment>
 		<rdfs:comment rdf:datatype="&xsd;string">gistTop</rdfs:comment>
 		<owl:versionIRI rdf:resource="https://ontologies.semanticarts.com/o/gistTopX.x.x"/>
-		<owl:versionInfo rdf:datatype="&xsd;string">Created with e6Tools Graphical OWL Editor from S:\_SemanticArts\Offerings\gist\_daveGistGit\gist\gistX.x.x.vsd Page:top</owl:versionInfo>
 		<gist:license rdf:datatype="&xsd;string">https://creativecommons.org/licenses/by-sa/3.0/</gist:license>
 	</owl:Ontology>
 	

--- a/OntologyFiles/gistUnit.owl
+++ b/OntologyFiles/gistUnit.owl
@@ -18,7 +18,6 @@
 		<rdfs:comment rdf:datatype="&xs;string">gistUnit</rdfs:comment>
 		<owl:imports rdf:resource="https://ontologies.semanticarts.com/o/gistTopX.x.x"/>
 		<owl:versionIRI rdf:resource="https://ontologies.semanticarts.com/o/gistUnitX.x.x"/>
-		<owl:versionInfo rdf:datatype="&xs;string">Created with e6Tools Graphical OWL Editor from S:\_SemanticArts\Offerings\gist\_daveGistGit\gist\gistX.x.x.vsd Page:unit</owl:versionInfo>
 		<gist:license rdf:datatype="&xs;string">https://creativecommons.org/licenses/by-sa/3.0/</gist:license>
 	</owl:Ontology>
 	

--- a/OntologyFiles/gistUnitDim.owl
+++ b/OntologyFiles/gistUnitDim.owl
@@ -18,7 +18,6 @@
 		<rdfs:comment rdf:datatype="&xs;string">gistX.x.x dimensioned units of measure.  This extension allows (and requires) you to have a conversion factor for all units with the same dimension.  If you introduce MilesPerHour you will have to supply the conversion to MetersPerSecond (even though the system &quot;knows&quot; how to convert Miles to meters and hours to seconds.  You will have to supply and addtional conversion when you introduce KilometersPerHour.  Any new combination of primtive rations requires a new Dimension.  While this is a burden, it allows units to be converted in sparql</rdfs:comment>
 		<owl:imports rdf:resource="https://ontologies.semanticarts.com/o/gistUnitX.x.x"/>
 		<owl:versionIRI rdf:resource="https://ontologies.semanticarts.com/o/gistUnitDimX.x.x"/>
-		<owl:versionInfo rdf:datatype="&xs;string">Created with e6Tools Graphical OWL Editor from S:\_SemanticArts\Offerings\gist\_daveGistGit\gist\gistX.x.x.vsd Page:UnitDim</owl:versionInfo>
 		<gist:license rdf:datatype="&xs;string">https://creativecommons.org/licenses/by-sa/3.0/</gist:license>
 	</owl:Ontology>
 	


### PR DESCRIPTION
@sa-bpelakh I believe ontology-toolkit adds the correct versionInfo, so they don't need to be in the source files. Can you confirm that?