### PR TITLE
Rename ontology files by appending version.

### DIFF
--- a/bundle.yaml
+++ b/bundle.yaml
@@ -34,6 +34,9 @@ actions:
   replace:
     from: "X.x.x"
     to: "{version}"
+  rename:
+    from: "(.*)\\.owl"
+    to: "\\g<1>{version}.owl"
   source: "{input}/OntologyFiles"
   target: "{output}"
   includes:


### PR DESCRIPTION
Can be used once https://github.com/semanticarts/ontology-toolkit/pull/22 is approved.