### PR TITLE
Remove redundant disjoints on UnitOfMeasure

### DIFF
--- a/OntologyFiles/gistTop.owl
+++ b/OntologyFiles/gistTop.owl
@@ -663,15 +663,6 @@
 	<owl:Class rdf:about="&gist;UnitOfMeasure">
 		<rdfs:label rdf:datatype="&xsd;string">Unit of Measure</rdfs:label>
 		<rdfs:comment rdf:datatype="&xsd;string">Standard unit by which we measure things</rdfs:comment>
-		<owl:disjointWith rdf:resource="&gist;Content"/>
-		<owl:disjointWith rdf:resource="&gist;GeoPoint"/>
-		<owl:disjointWith rdf:resource="&gist;GeoRegion"/>
-		<owl:disjointWith rdf:resource="&gist;IntellectualProperty"/>
-		<owl:disjointWith rdf:resource="&gist;Language"/>
-		<owl:disjointWith rdf:resource="&gist;Organization"/>
-		<owl:disjointWith rdf:resource="&gist;PhysicalIdentifiableItem"/>
-		<owl:disjointWith rdf:resource="&gist;SchemaMetaData"/>
-		<owl:disjointWith rdf:resource="&gist;Template"/>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&gist;Volume">


### PR DESCRIPTION
As discussed on Teams regarding my work on issue #243 there are redundant disjoints that could be removed.

Suggestion:  Remove redundant disjoints in gistTop, i.e. state the distjoint on just one side.  Ususally the one that occurs 1st alphabetically.  

Here's the teams discussion transcript:

> [9:18 AM] Mark Wallace
>     sa-gist, I have an issue where when I run the serializer, it removes a bunch of disjointness axioms, even though I didn't touch anything there.  Is anyone else seeing this?  
> ​[9:43 AM] Dalia Dahleh
>     I believe that's protege, not the serializer. When you save an ontology in protege it only writes one side of a symmetric property.
> ​[9:48 AM] Mark Wallace
>     Ah, ok  Wonder how many of us are using Protege?  More importantly, is it OK to "agree with " protege and let these come out (under a different atomic commit), or to keep having to "unstage that hunk" after I serialize from Protege? 
> ​[10:19 AM] Dalia Dahleh
>     Good question. **I'm thinking it might be better to remove them.** Not only to make it easier to save with protege, but also to make it more consistent. Most disjoints are only stated on one class in our gist files (even UnitOfMeasure has a few more that are only stated on the other class)
> ​[10:21 AM] Mark Wallace
>     ok, sounds goodl.  I'll take them out as another atomic commit
> Edited​[10:46 AM] Boris Pelakh
>     Is Protege consistent about which half of the symmetrical disjoint it drops? Should there be a standard? 
> ​[10:48 AM] Dalia Dahleh
>     It looks like it keeps the first, sorted alphabetically
> (2 liked)