### PR TITLE
orderedMemberOf is Functional, not Inverse Functional

### DIFF
--- a/OntologyFiles/gistMeasure.owl
+++ b/OntologyFiles/gistMeasure.owl
@@ -134,7 +134,7 @@
 	</owl:AnnotationProperty>
 	
 	<rdf:Description rdf:about="&gist;orderedMemberOf">
-		<rdf:type rdf:resource="&owl;InverseFunctionalProperty"/>
+		<rdf:type rdf:resource="&owl;FunctionalProperty"/>
 		<rdf:type rdf:resource="&owl;ObjectProperty"/>
 		<rdfs:label rdf:datatype="&xsd;string">Ordered Member Of</rdfs:label>
 		<rdfs:comment rdf:datatype="&xsd;string">An inverse of hasOrderedMember</rdfs:comment>


### PR DESCRIPTION
In the current model of each Ordered Member being
in at most 1 ordered list, the orderedMemberOf
property should be functional. Fixes #262