### PR TITLE
Issue 168 - grammar fix.

### DIFF
--- a/gistCore.owl
+++ b/gistCore.owl
@@ -2790,7 +2790,7 @@
 	
 	<owl:ObjectProperty rdf:about="&gist;characterizedAs">
 		<rdfs:label rdf:datatype="&xsd;string">Characterized As</rdfs:label>
-		<rdfs:comment rdf:datatype="&xsd;string">A way to categorized a behavior</rdfs:comment>
+		<rdfs:comment rdf:datatype="&xsd;string">A way to categorize a behavior.</rdfs:comment>
 		<rdfs:domain rdf:resource="&gist;Event"/>
 		<rdfs:range rdf:resource="&gist;Behavior"/>
 	</owl:ObjectProperty>


### PR DESCRIPTION
This is a re-do, without a problem with serialization.
"A way to categorized a behavior" was changed to "A way to categorize a behavior."
Signed-off-by: Meika Ungricht <meika.ungricht@semanticarts.com>