### PR TITLE
Deprecate gist:Room. 

### DIFF
--- a/gistCore.owl
+++ b/gistCore.owl
@@ -1901,8 +1901,6 @@
 					</rdf:Description>
 					<rdf:Description rdf:about="&gist;Landmark">
 					</rdf:Description>
-					<rdf:Description rdf:about="&gist;Room">
-					</rdf:Description>
 				</owl:unionOf>
 			</owl:Class>
 		</owl:equivalentClass>
@@ -2106,25 +2104,6 @@
 					<owl:Restriction>
 						<owl:onProperty rdf:resource="&gist;prevents"/>
 						<owl:someValuesFrom rdf:resource="&gist;Behavior"/>
-					</owl:Restriction>
-				</owl:intersectionOf>
-			</owl:Class>
-		</owl:equivalentClass>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&gist;Room">
-		<rdfs:label rdf:datatype="&xsd;string">Room</rdfs:label>
-		<rdfs:comment rdf:datatype="&xsd;string">An enclosed area within a building.</rdfs:comment>
-		<owl:equivalentClass>
-			<owl:Class>
-				<owl:intersectionOf rdf:parseType="Collection">
-					<owl:Restriction>
-						<owl:onProperty rdf:resource="&gist;directPartOf"/>
-						<owl:someValuesFrom rdf:resource="&gist;Building"/>
-					</owl:Restriction>
-					<owl:Restriction>
-						<owl:onProperty rdf:resource="&gist;identifiedBy"/>
-						<owl:someValuesFrom rdf:resource="&gist;ID"/>
 					</owl:Restriction>
 				</owl:intersectionOf>
 			</owl:Class>
@@ -2979,9 +2958,6 @@ Degrees K =  (Degrees F - conversionOffset) * convertToBase. Or K = (F-(-469.67)
 					<rdf:Description rdf:about="&gist;GeoVolume">
 					</rdf:Description>
 					<rdf:Description rdf:about="&gist;Landmark">
-					</rdf:Description>
-					<rdf:Description rdf:about="&gist;Room">
-					</rdf:Description>
 				</owl:unionOf>
 			</owl:Class>
 		</rdfs:domain>
@@ -2999,8 +2975,6 @@ Degrees K =  (Degrees F - conversionOffset) * convertToBase. Or K = (F-(-469.67)
 					<rdf:Description rdf:about="&gist;GeoVolume">
 					</rdf:Description>
 					<rdf:Description rdf:about="&gist;Landmark">
-					</rdf:Description>
-					<rdf:Description rdf:about="&gist;Room">
 					</rdf:Description>
 				</owl:unionOf>
 			</owl:Class>

--- a/gistDeprecated.owl
+++ b/gistDeprecated.owl
@@ -55,7 +55,28 @@
 			</owl:Class>
 		</owl:equivalentClass>
 	</owl:Class>
+
 	
+	<owl:Class rdf:about="&gist;Room">
+		<rdfs:label rdf:datatype="&xsd;string">Room</rdfs:label>
+		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
+		<rdfs:comment rdf:datatype="&xsd;string">An enclosed area within a building.</rdfs:comment>
+		<owl:equivalentClass>
+			<owl:Class>
+				<owl:intersectionOf rdf:parseType="Collection">
+					<owl:Restriction>
+						<owl:onProperty rdf:resource="&gist;directPartOf"/>
+						<owl:someValuesFrom rdf:resource="&gist;Building"/>
+					</owl:Restriction>
+					<owl:Restriction>
+						<owl:onProperty rdf:resource="&gist;identifiedBy"/>
+						<owl:someValuesFrom rdf:resource="&gist;ID"/>
+					</owl:Restriction>
+				</owl:intersectionOf>
+			</owl:Class>
+		</owl:equivalentClass>
+	</owl:Class>
+
 	<owl:Class rdf:about="&gist;SocialBeing">
 		<rdfs:label rdf:datatype="&xsd;string">Social Being</rdfs:label>
 		<rdfs:comment rdf:datatype="&xsd;string">A Person or an Organization.</rdfs:comment>


### PR DESCRIPTION
Fixes #102 

Note that gist:Room also had to be removed from three union classes (which are actually one union class repeated three times; see #334)