### PR TITLE
Substitute version in release notes. Fixes #359

### DIFF
--- a/bundle.yaml
+++ b/bundle.yaml
@@ -103,6 +103,9 @@ actions:
 - action: "copy"
   source: "{input}/docs"
   target: "{output}/Documentation"
+  replace:
+    from: "X.x.x"
+    to: "{version}"
   includes:
     - "ReleaseNotes.md"
 - action: "markdown"

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -109,7 +109,7 @@ actions:
   includes:
     - "ReleaseNotes.md"
 - action: "markdown"
-  source: "{input}/docs/ReleaseNotes.md"
+  source: "{output}/Documentation/ReleaseNotes.md"
   target: "{output}/Documentation/ReleaseNotes.html"
 - action: "move"
   source: "{output}"


### PR DESCRIPTION
Will still have to edit it permanently when we create the next version template after the release, and there is the pesky reminder text there as well, so not sure if it's worth it.