### PR TITLE
Generate legacy annotations. Fixes #379

### DIFF
--- a/bundle.yaml
+++ b/bundle.yaml
@@ -99,7 +99,7 @@ actions:
     - "*.ttl"
 - action: "sparql"
   source: "{output}"
-  target: "{output}/legacyAnnotations.ttl"
+  target: "{output}/rdfsAnnotations.ttl"
   format: "turtle"
   includes:
     - "*.ttl"
@@ -114,15 +114,21 @@ actions:
     WHERE {{
       {{ ?entity skos:prefLabel ?label }}
       UNION
-      {{ ?entity skos:altLabel|
-                 skos:definition|
-                 skos:example|
-                 skos:scopeNote ?comment }}
+      {{
+        VALUES (?prop ?prefix ) {{
+          ( skos:altLabel "ALT: " )
+          ( skos:definition "DEFINITION: " )
+          ( skos:example "EXAMPLE: " )
+          ( skos:scopeNote "NOTE: " )
+        }}
+        ?entity ?prop ?text .
+        BIND(CONCAT(?prefix, ?text) as ?comment)
+      }}
     }}
 - action: "transform"
   tool: "serializer"
-  source: "{output}/legacyAnnotations.ttl"
-  target: "{output}/legacyAnnotations.ttl"
+  source: "{output}/rdfsAnnotations.ttl"
+  target: "{output}/rdfsAnnotations.ttl"
 - action: "copy"
   source: "{input}/LICENSE.txt"
   target: "{output}"

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -97,6 +97,32 @@ actions:
     to: "\\g<1>.jsonld"
   includes:
     - "*.ttl"
+- action: "sparql"
+  source: "{output}"
+  target: "{output}/legacyAnnotations.ttl"
+  format: "turtle"
+  includes:
+    - "*.ttl"
+  query: >
+    prefix gist: <https://ontologies.semanticarts.com/gist/>
+    prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+    prefix skos: <http://www.w3.org/2004/02/skos/core#>
+    CONSTRUCT {{
+      ?entity rdfs:label ?label ;
+              rdfs:comment ?comment .
+    }}
+    WHERE {{
+      {{ ?entity skos:prefLabel ?label }}
+      UNION
+      {{ ?entity skos:altLabel|
+                 skos:definition|
+                 skos:example|
+                 skos:scopeNote ?comment }}
+    }}
+- action: "transform"
+  tool: "serializer"
+  source: "{output}/legacyAnnotations.ttl"
+  target: "{output}/legacyAnnotations.ttl"
 - action: "copy"
   source: "{input}/LICENSE.txt"
   target: "{output}"


### PR DESCRIPTION
This will only `legacyAnnotations.ttl` via CONSTRUCT query to restore the old `rdfs:label`/`rdfs:comment` annotations. I don't know the right release notes verbiage or whether we should also have a JSON-LD and RDF/XML versions of this file. 

PS This requires onto_tool v0.10.0 or later (including the fix in https://github.com/semanticarts/ontology-toolkit/pull/47, which is not yet merged at this time).