### PR TITLE
Add property gist:description. Fixes #425.

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -1,6 +1,15 @@
 gist Release Notes
 =====
 
+Release X.x.x [ADD APPROPRIATE VERSION NUMBER FOR RELEASE]
+-----
+
+### Minor Updates
+
+- Added datatype property `gist:description` for describing instance data. Issue [#425](https://github.com/semanticarts/gist/issues/425).
+
+Import URL: <https://ontologies.semanticarts.com/o/gistCoreX.x.x>. [ADD APPROPRIATE VERSION NUMBER FOR RELEASE]
+
 Release 9.5.0
 -----
 

--- a/gistCore.ttl
+++ b/gistCore.ttl
@@ -2978,6 +2978,13 @@ gist:describedIn
 	skos:prefLabel "Described In"^^xsd:string ;
 	.
 
+gist:description
+	a owl:DatatypeProperty ;
+	skos:definition "A statement about someone or something's attributes or characteristics."^^xsd:string ;
+	skos:example "The Empire State Building is a 102-story Art Deco skyscraper in Midtown Manhattan in New York City, United States. It was designed by Shreve, Lamb & Harmon and built from 1930 to 1931."^^xsd:string ;
+	skos:prefLabel "description"^^xsd:string ;
+	.
+
 gist:directPartOf
 	a owl:ObjectProperty ;
 	owl:inverseOf gist:hasDirectPart ;

--- a/gistCore.ttl
+++ b/gistCore.ttl
@@ -2983,6 +2983,7 @@ gist:description
 	skos:definition "A statement about someone or something's attributes or characteristics."^^xsd:string ;
 	skos:example "The Empire State Building is a 102-story Art Deco skyscraper in Midtown Manhattan in New York City, United States. It was designed by Shreve, Lamb & Harmon and built from 1930 to 1931."^^xsd:string ;
 	skos:prefLabel "description"^^xsd:string ;
+	skos:scopeNote "This property is intended to be used with instance data."^^xsd:string ;
 	.
 
 gist:directPartOf

--- a/gistCore.ttl
+++ b/gistCore.ttl
@@ -2983,7 +2983,7 @@ gist:description
 	skos:definition "A statement about someone or something's attributes or characteristics."^^xsd:string ;
 	skos:example "The Empire State Building is a 102-story Art Deco skyscraper in Midtown Manhattan in New York City, United States. It was designed by Shreve, Lamb & Harmon and built from 1930 to 1931."^^xsd:string ;
 	skos:prefLabel "description"^^xsd:string ;
-	skos:scopeNote "This property is intended to be used with instance data."^^xsd:string ;
+	skos:scopeNote "This property is used to provide a description of an instance entity in greater detail than a label."^^xsd:string ;
 	.
 
 gist:directPartOf


### PR DESCRIPTION
Add datatype property ```gist:description```.