### PR TITLE
v9.6.0: Correct labels to be compliant, formatting for release notes.

### DIFF
--- a/bundle.yaml
+++ b/bundle.yaml
@@ -61,6 +61,7 @@ actions:
   directory: "{validation}"
 # Validate ontology
 - action: "verify"
+  message: "Validating ontology via SHACL."
   type: "shacl"
   inference: "none"
   target: "{validation}/ontologyValidationReport.ttl"
@@ -73,6 +74,7 @@ actions:
 - action: "mkdir"
   directory: "{output}"
 - action: "copy"
+  message: "Substituting version numbers."
   source: "{input}"
   target: "{output}"
   replace:
@@ -84,17 +86,20 @@ actions:
   includes:
     - "*.ttl"
 - action: "definedBy"
+  message: "Adding rdfs:definedBy."
   source: "{output}"
   target: "{output}"
   includes:
     - "*.ttl"
 - action: "transform"
+  message: "Turtle serialization."
   tool: "serializer"
   source: "{output}"
   target: "{output}"
   includes:
     - "*.ttl"
 - action: "transform"
+  message: "RDF/XML serialization."
   tool: "xml-serializer"
   source: "{output}"
   target: "{output}"
@@ -104,6 +109,7 @@ actions:
   includes:
     - "*.ttl"
 - action: "transform"
+  message: "JSON/LD serialization."
   tool: "json-serializer"
   source: "{output}"
   target: "{output}"
@@ -113,6 +119,7 @@ actions:
   includes:
     - "*.ttl"
 - action: "sparql"
+  message: "Generating rdfs:label for backward compatibility."
   source: "{output}"
   target: "{output}/rdfsAnnotations.ttl"
   format: "turtle"
@@ -145,6 +152,7 @@ actions:
   source: "{output}/rdfsAnnotations.ttl"
   target: "{output}/rdfsAnnotations.ttl"
 - action: "copy"
+  message: "Copying license text."
   source: "{input}/LICENSE.txt"
   target: "{output}"
 - action: "copy"
@@ -153,9 +161,11 @@ actions:
   includes:
     - "ReleaseNotes.md"
 - action: "markdown"
+  message: "Formatting release notes."
   source: "{input}/docs/ReleaseNotes.md"
   target: "{output}/Documentation/ReleaseNotes.html"
 - action: "move"
+  message: "Creating Deprecated folder."
   source: "{output}"
   target: "{output}/Deprecated"
   includes:

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -7,21 +7,25 @@ Release 9.6.0
 ### Minor Updates
 
 - Added datatype property `gist:description` for describing instance data. Issue [#425](https://github.com/semanticarts/gist/issues/425).
-
-- Updated all `skos:prefLabel` values based on a newly-adopted convention. See the convention specification in the section on Labels in the [gist style guide](https://github.com/semanticarts/gist/blob/v9.5.0/docs/gistStyleGuide.md#Labels). Issues [#227](https://github.com/semanticarts/gist/issues/227) and [#421](https://github.com/semanticarts/gist/issues/421).
-
 - Refactored `hasParty`, `giver` and `getter`. Issue [#133](https://github.com/semanticarts/gist/issues/133).
+    - `giver` and `getter`
+        - Renamed to `hasGiver` and `hasGetter`
+        - The newly named versions are no longer subproperties of `hasParty`
+        - Deprecated `giver` and `getter`
+    - New property: `hasParticipant`
+        - No domain or range
+        - Has subproperties: `hasGiver`, `hasGetter`, `hasParty`, `fromAgent` and `toAgent`
+    - Added a `skos:scopeNote` to `fromAgent`
+    - Added a `skos:example` to `hasParty`
+    - Updated `skos:definition`s for `toAgent` and `fromAgent`
 
-  - `giver` and `getter`
-    - Renamed to `hasGiver` and `hasGetter`
-    - The newly named versions are no longer subproperties of `hasParty`
-    - Deprecated `giver` and `getter`
-  - New property: `hasParticipant`
-    - No domain or range
-    - Has subproperties: `hasGiver`, `hasGetter`, `hasParty`, `fromAgent` and `toAgent`
-  - Added a `skos:scopeNote` to `fromAgent`
-  - Added a `skos:example` to `hasParty`
-  - Updated `skos:definition`s for `toAgent` and `fromAgent`
+### Patch Updates
+
+- Updated all `skos:prefLabel` values based on a newly-adopted convention. See the convention specification in
+  the section on Labels in the [gist style guide](https://github.com/semanticarts/gist/blob/v9.5.0/docs/gistStyleGuide.md#Labels).
+  Added `skos:prefLabel` validation to build process for classes and properties.
+  Issues [#227](https://github.com/semanticarts/gist/issues/227) and
+  [#421](https://github.com/semanticarts/gist/issues/421).
 
 Import URL: <https://ontologies.semanticarts.com/o/gistCore9.6.0>.
 

--- a/gistCore.ttl
+++ b/gistCore.ttl
@@ -3243,14 +3243,14 @@ gist:hasGetter
 	rdfs:subPropertyOf gist:hasParticipant ;
 	owl:propertyDisjointWith gist:hasGiver ;
 	skos:definition "The recipient"^^xsd:string ;
-	skos:prefLabel "Has Getter"^^xsd:string ;
+	skos:prefLabel "has getter"^^xsd:string ;
 	.
 
 gist:hasGiver
 	a owl:ObjectProperty ;
 	rdfs:subPropertyOf gist:hasParticipant ;
 	skos:definition "The active party, the one with the obligation or the one initiating the transfer"^^xsd:string ;
-	skos:prefLabel "Has Giver"^^xsd:string ;
+	skos:prefLabel "has giver"^^xsd:string ;
 	.
 
 gist:hasGoal
@@ -3323,7 +3323,7 @@ gist:hasParticipant
 	a owl:ObjectProperty ;
 	skos:definition "Relates something (e.g. an agreement) to things that play a role, or take part or are otherwise involved in some way."^^xsd:string ;
 	skos:example "An event of transferring money has a participating account that receives the money."^^xsd:string ;
-	skos:prefLabel "Has Participant"^^xsd:string ;
+	skos:prefLabel "has participant"^^xsd:string ;
 	skos:scopeNote
 		"The thing with participants will often be an agreement, event or obligation."^^xsd:string ,
 		"This is intended as an abstract property. Only its subproperties will be directly used."^^xsd:string


### PR DESCRIPTION
Just cosmetics and a small fix for new labels introduced by Michael which were not compliant. Had to indent the nested lists in the release notes 4 spaces instead of 2 so they would be properly formatted by the markdown2HTML conversion.