### PR TITLE
Remove gist:Room. Fixes #102

### DIFF
--- a/docs/.markdownlint.json
+++ b/docs/.markdownlint.json
@@ -3,5 +3,6 @@
     "MD003": { "style": "setext_with_atx" },
     "MD013": false,
     "MD024": { "siblings_only": true },
-    "MD036": false
+    "MD036": false, 
+    "MD007": false
 }

--- a/docs/ChangeAndReleaseManagement.md
+++ b/docs/ChangeAndReleaseManagement.md
@@ -43,7 +43,7 @@ Additional notes:
 
 - Correction of an error, even if not backward-compatible, does not require a major release. The expectation is that users will not have implemented against an obvious error. This would be a patch.
 - When a local name is altered, the original term is deprecated to make it a minor rather than major change. The deprecated term receives an `owl:equivalentClass` or `owl:equivalentProperty` assertion to the new term. Deprecated terms may be removed in a future major release. Deprecated terms reside in the `gistDeprecated.ttl` file. If a user wants to use a deprecated term, he/she should import this file into his/her ontology, which in turn imports `gistCore.ttl` and thus all of gist.
-- Major changes should have a significant impact aside from technically modifying inferencing if this is low-impact. E.g.,when an equivalent class axiom to a union class is changed to a subclass axiom in order to allow new subclasses to be defined.
+- Major changes should have a significant impact aside from technically modifying inferencing if this is low-impact. E.g., when an equivalent class axiom to a union class is changed to a subclass axiom in order to allow new subclasses to be defined.
 
 Releases
 -----

--- a/docs/ChangeAndReleaseManagement.md
+++ b/docs/ChangeAndReleaseManagement.md
@@ -33,7 +33,7 @@ Version numbers are of the form X.x.x (major.minor.patch). We follow [Semantic V
 - **Major:** Non-backward-compatible (i.e., reasoning produces different results).
   - Examples: adding a restriction, domain, range.
 
-- **Minor:** New, backward-compatible functionality. May constitute a large change to the ontology, such as addition to new module.
+- **Minor:** New, backward-compatible functionality. May constitute a large change to the ontology, such as addition of a new module.
   - Examples: adding a class or property; removing a restriction.
 
 - **Patch:** No new functionality except for bug fixes.
@@ -43,7 +43,7 @@ Additional notes:
 
 - Correction of an error, even if not backward-compatible, does not require a major release. The expectation is that users will not have implemented against an obvious error. This would be a patch.
 - When a local name is altered, the original term is deprecated to make it a minor rather than major change. The deprecated term receives an `owl:equivalentClass` or `owl:equivalentProperty` assertion to the new term. Deprecated terms may be removed in a future major release. Deprecated terms reside in the `gistDeprecated.ttl` file. If a user wants to use a deprecated term, he/she should import this file into his/her ontology, which in turn imports `gistCore.ttl` and thus all of gist.
-- Major changes should have a significant impact aside from technically modifying inferencing if this is low-impact. E.g.,changing an equivalent class axiom to a union class to a subclass axiom in order to allow new subclasses to be defined. 
+- Major changes should have a significant impact aside from technically modifying inferencing if this is low-impact. E.g.,when an equivalent class axiom to a union class is changed to a subclass axiom in order to allow new subclasses to be defined.
 
 Releases
 -----

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -21,16 +21,16 @@ Release 9.6.0
 
 - Added datatype property `gist:description` for describing instance data. Issue [#425](https://github.com/semanticarts/gist/issues/425).
 - Refactored `hasParty`, `giver` and `getter`. Issue [#133](https://github.com/semanticarts/gist/issues/133).
-  - `giver` and `getter`
-    - Renamed to `hasGiver` and `hasGetter`
-    - The newly named versions are no longer subproperties of `hasParty`
-    - Deprecated `giver` and `getter`
-  - New property: `hasParticipant`
-    - No domain or range
-    - Has subproperties: `hasGiver`, `hasGetter`, `hasParty`, `fromAgent` and `toAgent`
-  - Added a `skos:scopeNote` to `fromAgent`
-  - Added a `skos:example` to `hasParty`
-  - Updated `skos:definition`s for `toAgent` and `fromAgent`
+    - `giver` and `getter`
+      - Renamed to `hasGiver` and `hasGetter`
+      - The newly named versions are no longer subproperties of `hasParty`
+      - Deprecated `giver` and `getter`
+    - New property: `hasParticipant`
+      - No domain or range
+      - Has subproperties: `hasGiver`, `hasGetter`, `hasParty`, `fromAgent` and `toAgent`
+    - Added a `skos:scopeNote` to `fromAgent`
+    - Added a `skos:example` to `hasParty`
+    - Updated `skos:definition`s for `toAgent` and `fromAgent`
 
 ### Patch Updates
 

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -25,7 +25,7 @@ Release 9.6.0
         - Renamed to `hasGiver` and `hasGetter`
         - The newly named versions are no longer subproperties of `hasParty`
         - Deprecated `giver` and `getter`
-        - New property: `hasParticipant`
+    - New property: `hasParticipant`
         - No domain or range
         - Has subproperties: `hasGiver`, `hasGetter`, `hasParty`, `fromAgent` and `toAgent`
     - Added a `skos:scopeNote` to `fromAgent`

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -22,12 +22,12 @@ Release 9.6.0
 - Added datatype property `gist:description` for describing instance data. Issue [#425](https://github.com/semanticarts/gist/issues/425).
 - Refactored `hasParty`, `giver` and `getter`. Issue [#133](https://github.com/semanticarts/gist/issues/133).
     - `giver` and `getter`
-      - Renamed to `hasGiver` and `hasGetter`
-      - The newly named versions are no longer subproperties of `hasParty`
-      - Deprecated `giver` and `getter`
-    - New property: `hasParticipant`
-      - No domain or range
-      - Has subproperties: `hasGiver`, `hasGetter`, `hasParty`, `fromAgent` and `toAgent`
+        - Renamed to `hasGiver` and `hasGetter`
+        - The newly named versions are no longer subproperties of `hasParty`
+        - Deprecated `giver` and `getter`
+        - New property: `hasParticipant`
+        - No domain or range
+        - Has subproperties: `hasGiver`, `hasGetter`, `hasParty`, `fromAgent` and `toAgent`
     - Added a `skos:scopeNote` to `fromAgent`
     - Added a `skos:example` to `hasParty`
     - Updated `skos:definition`s for `toAgent` and `fromAgent`

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -6,9 +6,9 @@ Release 10.0.0
 
 ### Major Updates
 
-### Minor Updates
+- Removed `gist:Room`. Issue [#102] (<https://github.com/semanticarts/gist/issues/102>).
 
-- Removed `gist:Room`. Issue [#102] (https://github.com/semanticarts/gist/issues/102).
+### Minor Updates
 
 ### Patch Updates
 

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -1,6 +1,19 @@
 gist Release Notes
 =====
 
+Release 10.0.0
+-----
+
+### Major Updates
+
+### Minor Updates
+
+- Removed `gist:Room`. Issue [#102] (https://github.com/semanticarts/gist/issues/102).
+
+### Patch Updates
+
+Import URL: <https://ontologies.semanticarts.com/o/gistCore10.0.0>.
+
 Release 9.6.0
 -----
 
@@ -8,16 +21,16 @@ Release 9.6.0
 
 - Added datatype property `gist:description` for describing instance data. Issue [#425](https://github.com/semanticarts/gist/issues/425).
 - Refactored `hasParty`, `giver` and `getter`. Issue [#133](https://github.com/semanticarts/gist/issues/133).
-    - `giver` and `getter`
-        - Renamed to `hasGiver` and `hasGetter`
-        - The newly named versions are no longer subproperties of `hasParty`
-        - Deprecated `giver` and `getter`
-    - New property: `hasParticipant`
-        - No domain or range
-        - Has subproperties: `hasGiver`, `hasGetter`, `hasParty`, `fromAgent` and `toAgent`
-    - Added a `skos:scopeNote` to `fromAgent`
-    - Added a `skos:example` to `hasParty`
-    - Updated `skos:definition`s for `toAgent` and `fromAgent`
+  - `giver` and `getter`
+    - Renamed to `hasGiver` and `hasGetter`
+    - The newly named versions are no longer subproperties of `hasParty`
+    - Deprecated `giver` and `getter`
+  - New property: `hasParticipant`
+    - No domain or range
+    - Has subproperties: `hasGiver`, `hasGetter`, `hasParty`, `fromAgent` and `toAgent`
+  - Added a `skos:scopeNote` to `fromAgent`
+  - Added a `skos:example` to `hasParty`
+  - Updated `skos:definition`s for `toAgent` and `fromAgent`
 
 ### Patch Updates
 

--- a/gistCore.ttl
+++ b/gistCore.ttl
@@ -2158,28 +2158,6 @@ gist:Restriction
 	skos:prefLabel "Restriction"^^xsd:string ;
 	.
 
-gist:Room
-	a owl:Class ;
-	rdfs:subClassOf gist:Place ;
-	owl:equivalentClass [
-		a owl:Class ;
-		owl:intersectionOf (
-			[
-				a owl:Restriction ;
-				owl:onProperty gist:directPartOf ;
-				owl:someValuesFrom gist:Building ;
-			]
-			[
-				a owl:Restriction ;
-				owl:onProperty gist:identifiedBy ;
-				owl:someValuesFrom gist:ID ;
-			]
-		) ;
-	] ;
-	skos:definition "An enclosed area within a building."^^xsd:string ;
-	skos:prefLabel "Room"^^xsd:string ;
-	.
-
 gist:ScheduledTask
 	a owl:Class ;
 	owl:equivalentClass [

--- a/gistDeprecated.ttl
+++ b/gistDeprecated.ttl
@@ -32,6 +32,29 @@ gist:PhysicalThing
 	] ;
 	.
 
+gist:Room
+	a owl:Class ;
+	rdfs:subClassOf gist:Place ;
+	owl:deprecated "true"^^xsd:boolean ;
+	owl:equivalentClass [
+		a owl:Class ;
+		owl:intersectionOf (
+			[
+				a owl:Restriction ;
+				owl:onProperty gist:directPartOf ;
+				owl:someValuesFrom gist:Building ;
+			]
+			[
+				a owl:Restriction ;
+				owl:onProperty gist:identifiedBy ;
+				owl:someValuesFrom gist:ID ;
+			]
+		) ;
+	] ;
+	skos:definition "An enclosed area within a building."^^xsd:string ;
+	skos:prefLabel "Room"^^xsd:string ;
+	.
+
 gist:SocialBeing
 	a owl:Class ;
 	rdfs:label "Social Being"^^xsd:string ;

--- a/gistDeprecated.ttl
+++ b/gistDeprecated.ttl
@@ -32,29 +32,6 @@ gist:PhysicalThing
 	] ;
 	.
 
-gist:Room
-	a owl:Class ;
-	rdfs:subClassOf gist:Place ;
-	owl:deprecated "true"^^xsd:boolean ;
-	owl:equivalentClass [
-		a owl:Class ;
-		owl:intersectionOf (
-			[
-				a owl:Restriction ;
-				owl:onProperty gist:directPartOf ;
-				owl:someValuesFrom gist:Building ;
-			]
-			[
-				a owl:Restriction ;
-				owl:onProperty gist:identifiedBy ;
-				owl:someValuesFrom gist:ID ;
-			]
-		) ;
-	] ;
-	skos:definition "An enclosed area within a building."^^xsd:string ;
-	skos:prefLabel "Room"^^xsd:string ;
-	.
-
 gist:SocialBeing
 	a owl:Class ;
 	rdfs:label "Social Being"^^xsd:string ;


### PR DESCRIPTION
Since this is for major release 10.0.0, the class is removed rather than deprecated.