### PR TITLE
Changes to gist:Person and gist:hasBirthDate. Fixes #136.

### DIFF
--- a/docs/.markdownlint.json
+++ b/docs/.markdownlint.json
@@ -3,5 +3,6 @@
     "MD003": { "style": "setext_with_atx" },
     "MD013": false,
     "MD024": { "siblings_only": true },
-    "MD036": false
+    "MD036": false,
+    "MD007": false
 }

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -24,16 +24,16 @@ Release 9.6.0
 
 - Added datatype property `gist:description` for describing instance data. Issue [#425](https://github.com/semanticarts/gist/issues/425).
 - Refactored `hasParty`, `giver` and `getter`. Issue [#133](https://github.com/semanticarts/gist/issues/133).
-  - `giver` and `getter`
-    - Renamed to `hasGiver` and `hasGetter`
-    - The newly named versions are no longer subproperties of `hasParty`
-    - Deprecated `giver` and `getter`
-  - New property: `hasParticipant`
-    - No domain or range
-    - Has subproperties: `hasGiver`, `hasGetter`, `hasParty`, `fromAgent` and `toAgent`
-  - Added a `skos:scopeNote` to `fromAgent`
-  - Added a `skos:example` to `hasParty`
-  - Updated `skos:definition`s for `toAgent` and `fromAgent`
+    - `giver` and `getter`
+        - Renamed to `hasGiver` and `hasGetter`
+        - The newly named versions are no longer subproperties of `hasParty`
+        - Deprecated `giver` and `getter`
+    - New property: `hasParticipant`
+        - No domain or range
+        - Has subproperties: `hasGiver`, `hasGetter`, `hasParty`, `fromAgent` and `toAgent`
+    - Added a `skos:scopeNote` to `fromAgent`
+    - Added a `skos:example` to `hasParty`
+    - Updated `skos:definition`s for `toAgent` and `fromAgent`
 
 ### Patch Updates
 

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -1,6 +1,22 @@
 gist Release Notes
 =====
 
+Release 10.0.0
+-----
+
+### Major Updates
+
+- Changes to and affecting `gist:Person`:
+  - Removed `owl:someValuesFrom gist:name` restriction from `gist:Person`.
+  - Made `gist:hasBirthDate` a subproperty of `gist:start` rather than `gist:actualStart`.
+Issue [#136](https://github.com/semanticarts/gist/issues/136).
+
+### Minor Updates
+
+### Patch Updates
+
+Import URL: <https://ontologies.semanticarts.com/o/gistCore10.0.0>.
+
 Release 9.6.0
 -----
 
@@ -8,16 +24,16 @@ Release 9.6.0
 
 - Added datatype property `gist:description` for describing instance data. Issue [#425](https://github.com/semanticarts/gist/issues/425).
 - Refactored `hasParty`, `giver` and `getter`. Issue [#133](https://github.com/semanticarts/gist/issues/133).
-    - `giver` and `getter`
-        - Renamed to `hasGiver` and `hasGetter`
-        - The newly named versions are no longer subproperties of `hasParty`
-        - Deprecated `giver` and `getter`
-    - New property: `hasParticipant`
-        - No domain or range
-        - Has subproperties: `hasGiver`, `hasGetter`, `hasParty`, `fromAgent` and `toAgent`
-    - Added a `skos:scopeNote` to `fromAgent`
-    - Added a `skos:example` to `hasParty`
-    - Updated `skos:definition`s for `toAgent` and `fromAgent`
+  - `giver` and `getter`
+    - Renamed to `hasGiver` and `hasGetter`
+    - The newly named versions are no longer subproperties of `hasParty`
+    - Deprecated `giver` and `getter`
+  - New property: `hasParticipant`
+    - No domain or range
+    - Has subproperties: `hasGiver`, `hasGetter`, `hasParty`, `fromAgent` and `toAgent`
+  - Added a `skos:scopeNote` to `fromAgent`
+  - Added a `skos:example` to `hasParty`
+  - Updated `skos:definition`s for `toAgent` and `fromAgent`
 
 ### Patch Updates
 

--- a/gistCore.ttl
+++ b/gistCore.ttl
@@ -1825,11 +1825,6 @@ gist:Person
 				owl:onProperty gist:offspringOf ;
 				owl:someValuesFrom gist:Person ;
 			]
-			[
-				a owl:Restriction ;
-				owl:onProperty gist:name ;
-				owl:someValuesFrom xsd:string ;
-			]
 		) ;
 	] ;
 	skos:definition "A human being that may or may not still be alive."^^xsd:string ;
@@ -3173,11 +3168,15 @@ gist:hasBaseUnit
 
 gist:hasBirthDate
 	a owl:ObjectProperty ;
-	rdfs:subPropertyOf gist:actualStart ;
+	rdfs:subPropertyOf gist:start ;
 	rdfs:domain gist:LivingThing ;
 	rdfs:range gist:TimeInstant ;
-	skos:definition 'Date a living thing was "born" (or germinated, for plants).'^^xsd:string ;
+	skos:definition "Date a living thing is or will be born."^^xsd:string ;
 	skos:prefLabel "has birthdate"^^xsd:string ;
+	skos:scopeNote
+		"This property is a subproperty of gist:start, rather than gist:actualStart (as formerly), to acknowledge the fact that the birth may not yet have occurred. In this case, the birthdate is expected although not known."^^xsd:string ,
+		"While most mammals are born when they emerge live from the uterus, birth is defined in other ways for other types of organisms. For example, a bird or reptile is born when it hatches;  a plant is 'born' when it sprouts; a cell is 'born' when the parent cell divides."^^xsd:string
+		;
 	.
 
 gist:hasCommunicationAddress

--- a/gistCore.ttl
+++ b/gistCore.ttl
@@ -3151,10 +3151,7 @@ gist:hasBirthDate
 	rdfs:range gist:TimeInstant ;
 	skos:definition "Date a living thing is or will be born."^^xsd:string ;
 	skos:prefLabel "has birthdate"^^xsd:string ;
-	skos:scopeNote
-		"This property is a subproperty of gist:start, rather than gist:actualStart (as formerly), to acknowledge the fact that the birth may not yet have occurred. In this case, the birthdate is expected although not known."^^xsd:string ,
-		"While most mammals are born when they emerge live from the uterus, birth is defined in other ways for other types of organisms. For example, a bird or reptile is born when it hatches;  a plant is 'born' when it sprouts; a cell is 'born' when the parent cell divides."^^xsd:string
-		;
+	skos:scopeNote "This property is a subproperty of gist:start, rather than gist:actualStart (as formerly), to acknowledge the fact that the birth may not yet have occurred. In this case, the birthdate is expected although not known."^^xsd:string ;
 	.
 
 gist:hasCommunicationAddress


### PR DESCRIPTION
@uschold:  Please review scope notes on `gist:hasBirthDate`. It may be extraneous detail, but I'm trying to clarify the meaning relative to different types of living things, given that there had been a mention of plants. Perhaps a better option is to remove all mention of other organisms, simply define it as the date something is born, and leave it up to the scientists to specify exactly what that means. Let me know what you think.

Boris has approved this but please comment.
