### PR TITLE
Change range of fromPlace & toPlace to include Address. Fixes #392

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -14,6 +14,9 @@ Issue [#136](https://github.com/semanticarts/gist/issues/136).
 
 - Removed `gist:Room`. Issue [#102](<https://github.com/semanticarts/gist/issues/102>).
 
+- Add `gist:Address` to the range of `gist:fromPlace` and `gist:toPlace`. Range is now `(gist:Address or
+  gist:Place)`.  Issue [#392](https://github.com/semanticarts/gist/issues/392).
+
 ### Minor Updates
 
 ### Patch Updates

--- a/gistCore.ttl
+++ b/gistCore.ttl
@@ -1522,8 +1522,8 @@ gist:Message
 				owl:someValuesFrom [
 					a owl:Class ;
 					owl:unionOf (
-						gist:Person
 						gist:Organization
+						gist:Person
 					) ;
 				] ;
 			]
@@ -1533,8 +1533,8 @@ gist:Message
 				owl:someValuesFrom [
 					a owl:Class ;
 					owl:unionOf (
-						gist:Person
 						gist:Organization
+						gist:Person
 					) ;
 				] ;
 			]
@@ -1689,6 +1689,11 @@ gist:Offer
 			gist:ContingentObligation
 			[
 				a owl:Restriction ;
+				owl:onProperty gist:hasDirectPart ;
+				owl:someValuesFrom gist:CatalogItem ;
+			]
+			[
+				a owl:Restriction ;
 				owl:onProperty gist:hasGiver ;
 				owl:someValuesFrom [
 					a owl:Class ;
@@ -1697,11 +1702,6 @@ gist:Offer
 						gist:Person
 					) ;
 				] ;
-			]
-			[
-				a owl:Restriction ;
-				owl:onProperty gist:hasDirectPart ;
-				owl:someValuesFrom gist:CatalogItem ;
 			]
 			[
 				a owl:Restriction ;
@@ -1908,6 +1908,7 @@ gist:PhysicalIdentifiableItem
 gist:PhysicalSubstance
 	a owl:Class ;
 	rdfs:subClassOf [
+		a owl:Class ;
 		owl:intersectionOf (
 			[
 				a owl:Restriction ;
@@ -3046,7 +3047,13 @@ gist:fromAgent
 
 gist:fromPlace
 	a owl:ObjectProperty ;
-	rdfs:range gist:Place ;
+	rdfs:range [
+		a owl:Class ;
+		owl:unionOf (
+			gist:Address
+			gist:Place
+		) ;
+	] ;
 	skos:definition "Origin"^^xsd:string ;
 	skos:prefLabel "from place"^^xsd:string ;
 	.
@@ -3788,7 +3795,13 @@ gist:toAgent
 
 gist:toPlace
 	a owl:ObjectProperty ;
-	rdfs:range gist:Place ;
+	rdfs:range [
+		a owl:Class ;
+		owl:unionOf (
+			gist:Address
+			gist:Place
+		) ;
+	] ;
 	skos:definition "Destination"^^xsd:string ;
 	skos:prefLabel "to place"^^xsd:string ;
 	.


### PR DESCRIPTION
A few items not central to the change were re-ordered by Protege, but properly so, so I think we should keep them. 