### PR TITLE
Revert changes to gist:Person and gist:hasBirthDate. Fixes #458.

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -4,14 +4,6 @@ gist Release Notes
 Release 9.7.0
 -----
 
-### Major Updates
-
-- Changes to and affecting `gist:Person`:
-
-  - Removed `owl:someValuesFrom gist:name` restriction from `gist:Person`.
-  - Made `gist:hasBirthDate` a subproperty of `gist:start` rather than `gist:actualStart`.
-Issue [#136](https://github.com/semanticarts/gist/issues/136).
-
 ### Minor Updates
 
 - Deprecated `gist:Room`. Issue [#102](<https://github.com/semanticarts/gist/issues/102>).

--- a/gistCore.ttl
+++ b/gistCore.ttl
@@ -1825,6 +1825,11 @@ gist:Person
 				owl:onProperty gist:offspringOf ;
 				owl:someValuesFrom gist:Person ;
 			]
+			[
+				a owl:Restriction ;
+				owl:onProperty gist:name ;
+				owl:someValuesFrom xsd:string ;
+			]
 		) ;
 	] ;
 	skos:definition "A human being that may or may not still be alive."^^xsd:string ;
@@ -3146,12 +3151,12 @@ gist:hasBaseUnit
 
 gist:hasBirthDate
 	a owl:ObjectProperty ;
-	rdfs:subPropertyOf gist:start ;
+	rdfs:subPropertyOf gist:actualStart ;
 	rdfs:domain gist:LivingThing ;
 	rdfs:range gist:TimeInstant ;
 	skos:definition "Date a living thing is or will be born."^^xsd:string ;
+	skos:editorialNote "For 10.0.0 release: This property will be a subproperty of gist:start, rather than gist:actualStart (as currently), to acknowledge the fact that the birth may not yet have occurred. In this case, the birthdate is expected although not known. [Change this note to a skos:scopeNote.]"^^xsd:string ;
 	skos:prefLabel "has birthdate"^^xsd:string ;
-	skos:scopeNote "This property is a subproperty of gist:start, rather than gist:actualStart (as formerly), to acknowledge the fact that the birth may not yet have occurred. In this case, the birthdate is expected although not known."^^xsd:string ;
 	.
 
 gist:hasCommunicationAddress


### PR DESCRIPTION
The changes in PR 449 were major changes. The next major release has been postponed by one month, so the changes need to be reverted for 9.7.0 and restored for 10.0.0.