### PR TITLE
Fix nested list indents in ReleaseNotes.

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -11,9 +11,9 @@ Release 9.7.0
 ### Patch Updates
 
 - Updated annotations for the following properties regarding the hasDirectX/hasX pattern. Issue [#115](https://github.com/semanticarts/gist/issues/115)
-  - `geoContains`, `geoContainedIn` 
-  - `directPartOf`,`hasDirectPart`
-  - `directlyPrecededBy`, `directlyPrecedes`
+    - `geoContains`, `geoContainedIn` 
+    - `directPartOf`,`hasDirectPart`
+    - `directlyPrecededBy`, `directlyPrecedes`
 - Declare `gist:identifies` as `owl:FunctionalProperty` rather than `owl:InverseFunctionalProperty` (bug fix). Issue [#180](https://github.com/semanticarts/gist/issues/180).
 
 Import URL: <https://ontologies.semanticarts.com/o/gistCore9.7.0>.


### PR DESCRIPTION
I had to make a small fix in ReleaseNotes for proper HTML rendering. This is due to a bug in the python Markdown module that messes up nested lists. As soon as you inspect, I can proceed w/ the release process, I have already regenerated the archive as part of testing this patch.