### PR TITLE
Rename MimeType to MediaType, create ontology to declare instances. Fixes #434, #463

### DIFF
--- a/bundle.yaml
+++ b/bundle.yaml
@@ -63,6 +63,7 @@ actions:
   source: "{input}"
   includes:
     - gistCore.ttl
+    - gistMediaTypes.ttl
     - gistValidationAnnotations.ttl
   shapes:
     source: "{input}/ontologyShapes.ttl"
@@ -80,6 +81,7 @@ actions:
     to: "\\g<1>{version}.ttl"
   includes:
     - gistCore.ttl
+    - gistMediaTypes.ttl
     - gistDeprecated.ttl
 - action: "definedBy"
   message: "Adding rdfs:definedBy."

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -1,6 +1,23 @@
 gist Release Notes
 =====
 
+Release 10.0.0
+-----
+
+### Major Updates
+
+- Renamed `MimeType` to `MediaType` to be consistent with [IANA guidelines](https://www.iana.org/assignments/media-types/media-types.xhtml)
+  and [RFC6838](https://tools.ietf.org/html/rfc6838). Issue [#434](<https://github.com/semanticarts/gist/issues/434>).
+
+### Minor Updates
+
+- Created a `gistMediaTypes` ontology to declare `MediaType` instances relevant to semantic applications.
+  Issue [#463](<https://github.com/semanticarts/gist/issues/463>).
+
+### Patch Updates
+
+Import URL: <https://ontologies.semanticarts.com/o/gistCore10.0.0>.
+
 Release 9.7.0
 -----
 

--- a/gistCore.ttl
+++ b/gistCore.ttl
@@ -9,8 +9,8 @@
 <https://ontologies.semanticarts.com/o/gistCore>
 	a owl:Ontology ;
 	owl:versionIRI <https://ontologies.semanticarts.com/o/gistCoreX.x.x> ;
-	skos:definition "Gist is a minimalist upper ontology created by Semantic Arts"^^xsd:string ;
-	skos:prefLabel "gistCore"^^xsd:string ;
+	skos:definition "gist is a minimalist upper ontology created by Semantic Arts"^^xsd:string ;
+	skos:prefLabel "gist Core"^^xsd:string ;
 	gist:license "https://creativecommons.org/licenses/by-sa/3.0/"^^xsd:string ;
 	.
 

--- a/gistCore.ttl
+++ b/gistCore.ttl
@@ -1506,8 +1506,9 @@ gist:MassUnit
 gist:MediaType
 	a owl:Class ;
 	rdfs:subClassOf gist:Category ;
+	rdfs:seeAlso <https://www.iana.org/assignments/media-types/media-types.xhtml> ;
 	skos:definition "A digitized type that computer applications can recognize."^^xsd:string ;
-	skos:prefLabel "MIME Type"^^xsd:string ;
+	skos:prefLabel "Media Type"^^xsd:string ;
 	.
 
 gist:Medium

--- a/gistCore.ttl
+++ b/gistCore.ttl
@@ -940,7 +940,7 @@ gist:FormattedContent
 			[
 				a owl:Restriction ;
 				owl:onProperty gist:expressedIn ;
-				owl:someValuesFrom gist:MimeType ;
+				owl:someValuesFrom gist:MediaType ;
 			]
 		) ;
 	] ;
@@ -1503,6 +1503,13 @@ gist:MassUnit
 	skos:prefLabel "Mass Unit"^^xsd:string ;
 	.
 
+gist:MediaType
+	a owl:Class ;
+	rdfs:subClassOf gist:Category ;
+	skos:definition "A digitized type that computer applications can recognize."^^xsd:string ;
+	skos:prefLabel "MIME Type"^^xsd:string ;
+	.
+
 gist:Medium
 	a owl:Class ;
 	rdfs:subClassOf gist:Category ;
@@ -1550,13 +1557,6 @@ gist:MessageDefinition
 	rdfs:subClassOf gist:SchemaMetaData ;
 	skos:definition "Each pulse from a Sensor is reflected in a message, as well as each instruction to an Actuator"^^xsd:string ;
 	skos:prefLabel "Message Definition"^^xsd:string ;
-	.
-
-gist:MimeType
-	a owl:Class ;
-	rdfs:subClassOf gist:Category ;
-	skos:definition "A digitized type that computer applications can recognize."^^xsd:string ;
-	skos:prefLabel "MIME Type"^^xsd:string ;
 	.
 
 gist:MolarQuantity
@@ -2121,7 +2121,7 @@ gist:RenderedContent
 			[
 				a owl:Restriction ;
 				owl:onProperty gist:expressedIn ;
-				owl:someValuesFrom gist:MimeType ;
+				owl:someValuesFrom gist:MediaType ;
 			]
 			[
 				a owl:Restriction ;

--- a/gistMediaTypes.ttl
+++ b/gistMediaTypes.ttl
@@ -1,0 +1,93 @@
+# imports: https://ontologies.semanticarts.com/o/gistCore
+
+@prefix gist: <https://ontologies.semanticarts.com/gist/> .
+@prefix mimeapp: <https://www.iana.org/assignments/media-types/application/> .
+@prefix mimetxt: <https://www.iana.org/assignments/media-types/text/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<https://ontologies.semanticarts.com/o/gistMediaTypes>
+	a owl:Ontology ;
+	owl:imports <https://ontologies.semanticarts.com/o/gistCore> ;
+	owl:versionIRI <https://ontologies.semanticarts.com/o/gistMediaTypesX.x.x> ;
+	skos:definition "Definitions of IANA Media Types."^^xsd:string ;
+	skos:prefLabel "gistMediaTypes"^^xsd:string ;
+	gist:license "https://creativecommons.org/licenses/by-sa/3.0/"^^xsd:string ;
+	.
+
+mimeapp:json
+	a gist:MimeType ;
+	skos:prefLabel "JSON"^^xsd:string ;
+	gist:uniqueText "application/json"^^xsd:string ;
+	.
+
+<https://www.iana.org/assignments/media-types/application/ld+json>
+	a gist:MimeType ;
+	skos:prefLabel "JSON-LD"^^xsd:string ;
+	gist:uniqueText "application/ld+json"^^xsd:string ;
+	.
+
+mimeapp:n-quads
+	a gist:MimeType ;
+	skos:prefLabel "N-Quads"^^xsd:string ;
+	gist:uniqueText "application/n-quads"^^xsd:string ;
+	.
+
+mimeapp:n-triples
+	a gist:MimeType ;
+	skos:prefLabel "N-Triples"^^xsd:string ;
+	gist:uniqueText "application/n-triples"^^xsd:string ;
+	.
+
+<https://www.iana.org/assignments/media-types/application/rdf+xml>
+	a gist:MimeType ;
+	skos:prefLabel "RDF/XML"^^xsd:string ;
+	gist:uniqueText "application/rdf+xml"^^xsd:string ;
+	.
+
+<https://www.iana.org/assignments/media-types/application/sparql-results+json>
+	a gist:MimeType ;
+	skos:prefLabel "SPARQL 1.1 Query Results JSON"^^xsd:string ;
+	gist:uniqueText "application/sparql-results+json"^^xsd:string ;
+	.
+
+<https://www.iana.org/assignments/media-types/application/sparql-results+xml>
+	a gist:MimeType ;
+	skos:prefLabel "SPARQL 1.1 Query Results XML"^^xsd:string ;
+	gist:uniqueText "application/sparql-results+xml"^^xsd:string ;
+	.
+
+mimeapp:trig
+	a gist:MimeType ;
+	skos:prefLabel "TriG"^^xsd:string ;
+	gist:uniqueText "application/trig"^^xsd:string ;
+	.
+
+mimetxt:csv
+	a gist:MimeType ;
+	skos:prefLabel "CSV"^^xsd:string ;
+	gist:uniqueText "text/csv"^^xsd:string ;
+	.
+
+mimetxt:html
+	a gist:MimeType ;
+	skos:prefLabel "HTML"^^xsd:string ;
+	gist:uniqueText "text/html"^^xsd:string ;
+	.
+
+mimetxt:plain
+	a gist:MimeType ;
+	skos:prefLabel "Plain Text"^^xsd:string ;
+	gist:uniqueText "text/plain"^^xsd:string ;
+	.
+
+mimetxt:turtle
+	a gist:MimeType ;
+	skos:prefLabel "Turtle"^^xsd:string ;
+	gist:uniqueText "text/turtle"^^xsd:string ;
+	.
+

--- a/gistMediaTypes.ttl
+++ b/gistMediaTypes.ttl
@@ -20,73 +20,73 @@
 	.
 
 media-app:json
-	a gist:MimeType ;
+	a gist:MediaType ;
 	skos:prefLabel "JSON"^^xsd:string ;
 	gist:uniqueText "application/json"^^xsd:string ;
 	.
 
 <https://www.iana.org/assignments/media-types/application/ld+json>
-	a gist:MimeType ;
+	a gist:MediaType ;
 	skos:prefLabel "JSON-LD"^^xsd:string ;
 	gist:uniqueText "application/ld+json"^^xsd:string ;
 	.
 
 media-app:n-quads
-	a gist:MimeType ;
+	a gist:MediaType ;
 	skos:prefLabel "N-Quads"^^xsd:string ;
 	gist:uniqueText "application/n-quads"^^xsd:string ;
 	.
 
 media-app:n-triples
-	a gist:MimeType ;
+	a gist:MediaType ;
 	skos:prefLabel "N-Triples"^^xsd:string ;
 	gist:uniqueText "application/n-triples"^^xsd:string ;
 	.
 
 <https://www.iana.org/assignments/media-types/application/rdf+xml>
-	a gist:MimeType ;
+	a gist:MediaType ;
 	skos:prefLabel "RDF/XML"^^xsd:string ;
 	gist:uniqueText "application/rdf+xml"^^xsd:string ;
 	.
 
 <https://www.iana.org/assignments/media-types/application/sparql-results+json>
-	a gist:MimeType ;
+	a gist:MediaType ;
 	skos:prefLabel "SPARQL 1.1 Query Results JSON"^^xsd:string ;
 	gist:uniqueText "application/sparql-results+json"^^xsd:string ;
 	.
 
 <https://www.iana.org/assignments/media-types/application/sparql-results+xml>
-	a gist:MimeType ;
+	a gist:MediaType ;
 	skos:prefLabel "SPARQL 1.1 Query Results XML"^^xsd:string ;
 	gist:uniqueText "application/sparql-results+xml"^^xsd:string ;
 	.
 
 media-app:trig
-	a gist:MimeType ;
+	a gist:MediaType ;
 	skos:prefLabel "TriG"^^xsd:string ;
 	gist:uniqueText "application/trig"^^xsd:string ;
 	.
 
 media-txt:csv
-	a gist:MimeType ;
+	a gist:MediaType ;
 	skos:prefLabel "CSV"^^xsd:string ;
 	gist:uniqueText "text/csv"^^xsd:string ;
 	.
 
 media-txt:html
-	a gist:MimeType ;
+	a gist:MediaType ;
 	skos:prefLabel "HTML"^^xsd:string ;
 	gist:uniqueText "text/html"^^xsd:string ;
 	.
 
 media-txt:plain
-	a gist:MimeType ;
+	a gist:MediaType ;
 	skos:prefLabel "Plain Text"^^xsd:string ;
 	gist:uniqueText "text/plain"^^xsd:string ;
 	.
 
 media-txt:turtle
-	a gist:MimeType ;
+	a gist:MediaType ;
 	skos:prefLabel "Turtle"^^xsd:string ;
 	gist:uniqueText "text/turtle"^^xsd:string ;
 	.

--- a/gistMediaTypes.ttl
+++ b/gistMediaTypes.ttl
@@ -1,8 +1,8 @@
 # imports: https://ontologies.semanticarts.com/o/gistCore
 
 @prefix gist: <https://ontologies.semanticarts.com/gist/> .
-@prefix mimeapp: <https://www.iana.org/assignments/media-types/application/> .
-@prefix mimetxt: <https://www.iana.org/assignments/media-types/text/> .
+@prefix media-app: <https://www.iana.org/assignments/media-types/application/> .
+@prefix media-txt: <https://www.iana.org/assignments/media-types/text/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
@@ -19,7 +19,7 @@
 	gist:license "https://creativecommons.org/licenses/by-sa/3.0/"^^xsd:string ;
 	.
 
-mimeapp:json
+media-app:json
 	a gist:MimeType ;
 	skos:prefLabel "JSON"^^xsd:string ;
 	gist:uniqueText "application/json"^^xsd:string ;
@@ -31,13 +31,13 @@ mimeapp:json
 	gist:uniqueText "application/ld+json"^^xsd:string ;
 	.
 
-mimeapp:n-quads
+media-app:n-quads
 	a gist:MimeType ;
 	skos:prefLabel "N-Quads"^^xsd:string ;
 	gist:uniqueText "application/n-quads"^^xsd:string ;
 	.
 
-mimeapp:n-triples
+media-app:n-triples
 	a gist:MimeType ;
 	skos:prefLabel "N-Triples"^^xsd:string ;
 	gist:uniqueText "application/n-triples"^^xsd:string ;
@@ -61,31 +61,31 @@ mimeapp:n-triples
 	gist:uniqueText "application/sparql-results+xml"^^xsd:string ;
 	.
 
-mimeapp:trig
+media-app:trig
 	a gist:MimeType ;
 	skos:prefLabel "TriG"^^xsd:string ;
 	gist:uniqueText "application/trig"^^xsd:string ;
 	.
 
-mimetxt:csv
+media-txt:csv
 	a gist:MimeType ;
 	skos:prefLabel "CSV"^^xsd:string ;
 	gist:uniqueText "text/csv"^^xsd:string ;
 	.
 
-mimetxt:html
+media-txt:html
 	a gist:MimeType ;
 	skos:prefLabel "HTML"^^xsd:string ;
 	gist:uniqueText "text/html"^^xsd:string ;
 	.
 
-mimetxt:plain
+media-txt:plain
 	a gist:MimeType ;
 	skos:prefLabel "Plain Text"^^xsd:string ;
 	gist:uniqueText "text/plain"^^xsd:string ;
 	.
 
-mimetxt:turtle
+media-txt:turtle
 	a gist:MimeType ;
 	skos:prefLabel "Turtle"^^xsd:string ;
 	gist:uniqueText "text/turtle"^^xsd:string ;

--- a/gistMediaTypes.ttl
+++ b/gistMediaTypes.ttl
@@ -15,7 +15,7 @@
 	owl:imports <https://ontologies.semanticarts.com/o/gistCore> ;
 	owl:versionIRI <https://ontologies.semanticarts.com/o/gistMediaTypesX.x.x> ;
 	skos:definition "Definitions of IANA Media Types."^^xsd:string ;
-	skos:prefLabel "gistMediaTypes"^^xsd:string ;
+	skos:prefLabel "gist Media Types"^^xsd:string ;
 	gist:license "https://creativecommons.org/licenses/by-sa/3.0/"^^xsd:string ;
 	.
 

--- a/ontologyShapes.ttl
+++ b/ontologyShapes.ttl
@@ -22,13 +22,12 @@
 		<http://www.w3.org/ns/shacl#>
 		;
 	skos:definition "Shapes to enforce ontology style."^^xsd:string ;
-	skos:prefLabel "ontologyShapes"^^xsd:string ;
+	skos:prefLabel "Ontology Shapes"^^xsd:string ;
 	.
 
 gshapes:ClassShape
 	a sh:NodeShape ;
-	rdfs:label "Class"^^xsd:string ;
-	skos:prefLabel "Class"^^xsd:string ;
+	skos:prefLabel "Class Shape"^^xsd:string ;
 	sh:or (
 		gshapes:TitleCase
 		gshapes:NonConformingLabel
@@ -44,8 +43,7 @@ gshapes:ClassShape
 
 gshapes:InstanceShape
 	a sh:NodeShape ;
-	rdfs:label "Instance"^^xsd:string ;
-	skos:prefLabel "Instance"^^xsd:string ;
+	skos:prefLabel "Instance Shape"^^xsd:string ;
 	sh:property [
 		sh:message "Instance references undefined class."^^xsd:string ;
 		sh:or (
@@ -77,7 +75,7 @@ gshapes:InstanceShape
 
 gshapes:LowerCase
 	a sh:PropertyShape ;
-	skos:definition "Enforces Lower Case, allowing for all-caps words for acronyms, as well as numbers."^^xsd:string ;
+	skos:definition "Enforces lower case, allowing for all-caps words for acronyms, as well as numbers."^^xsd:string ;
 	skos:editorialNote "Entities which require a prefLabel that does not conform to this rule should be annotated with gist:nonConformingLabel to pass validation."^^xsd:string ;
 	sh:maxCount "1"^^xsd:integer ;
 	sh:minCount "1"^^xsd:integer ;
@@ -104,8 +102,7 @@ gshapes:NonConformingLabel
 
 gshapes:PropertyShape
 	a sh:NodeShape ;
-	rdfs:label "Property"^^xsd:string ;
-	skos:prefLabel "Property"^^xsd:string ;
+	skos:prefLabel "Property Shape"^^xsd:string ;
 	sh:or (
 		gshapes:LowerCase
 		gshapes:NonConformingLabel
@@ -131,7 +128,7 @@ gshapes:SentenceCase
 
 gshapes:TitleCase
 	a sh:PropertyShape ;
-	skos:definition "Enforces Title Case, allowing for numbers, all-caps words for acronyms and lower case conjunctions and prepositions."^^xsd:string ;
+	skos:definition "Enforces title case, allowing for numbers, all-caps words for acronyms and lower case conjunctions and prepositions."^^xsd:string ;
 	skos:editorialNote "Entities which require a prefLabel that does not conform to this rule should be annotated with gist:nonConformingLabel to pass validation."^^xsd:string ;
 	sh:maxCount "1"^^xsd:integer ;
 	sh:minCount "1"^^xsd:integer ;

--- a/ontologyShapes.ttl
+++ b/ontologyShapes.ttl
@@ -42,6 +42,39 @@ gshapes:ClassShape
 	] ;
 	.
 
+gshapes:InstanceShape
+	a sh:NodeShape ;
+	rdfs:label "Instance"^^xsd:string ;
+	skos:prefLabel "Instance"^^xsd:string ;
+	sh:property [
+		sh:message "Instance references undefined class."^^xsd:string ;
+		sh:or (
+			[
+				sh:in (
+					owl:Class
+					owl:AllDifferent
+					owl:InverseFunctionalProperty
+					owl:DatatypeProperty
+					owl:TransitiveProperty
+					owl:FunctionalProperty
+					owl:ObjectProperty
+					owl:Restriction
+					owl:NamedIndividual
+					owl:Thing
+					owl:AnnotationProperty
+					owl:Ontology
+				) ;
+			]
+			[
+				sh:class owl:Class ;
+			]
+		) ;
+		sh:path a ;
+	] ;
+	sh:severity sh:Violation ;
+	sh:targetSubjectsOf a ;
+	.
+
 gshapes:LowerCase
 	a sh:PropertyShape ;
 	skos:definition "Enforces Lower Case, allowing for all-caps words for acronyms, as well as numbers."^^xsd:string ;


### PR DESCRIPTION
@mkumba There was extensive debate about this issue, and your input was requested. I followed the approach @Jamie-SA and I favored, which was to create annotations for existing IANA media type pages by adding types and labels.

@rjyounes and some others said we should not be creating statements using entities we do not own as subjects, and suggested I follow this pattern instead:

```
gist:_MediaType_TextHtml 
    a gist:MediaType; 
    gist:uniqueText "text/html";
    owl:sameAs iana:text\/html .
```

Creating a duplicate instance in the `gist` namespace for each of the media types. Do you have strong feeling in either direction?