### PR TITLE
Refactor physical addresses, Fixes #483

### DIFF
--- a/bundle.yaml
+++ b/bundle.yaml
@@ -67,6 +67,18 @@ actions:
     - gistValidationAnnotations.ttl
   shapes:
     source: "{input}/ontologyShapes.ttl"
+- action: "verify"
+  message: "Verify ontology via queries."
+  type: "construct"
+  inference: "none"
+  source: "{input}"
+  includes:
+    - gistCore.ttl
+  stopOnFail: false
+  queries:
+    source: '{input}/validation_queries'
+    includes:
+      - '*_construct.rq'
 - action: "mkdir"
   directory: "{output}"
 - action: "copy"

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -8,6 +8,13 @@ Release 10.0.0
 
 - Renamed `MimeType` to `MediaType` to be consistent with [IANA guidelines](https://www.iana.org/assignments/media-types/media-types.xhtml)
   and [RFC6838](https://tools.ietf.org/html/rfc6838). Issue [#434](<https://github.com/semanticarts/gist/issues/434>).
+- Modified classes and properties related to street addresses as per issue [#483](<https://github.com/semanticarts/gist/issues/483>):
+    - Removed `BuildingAddress`
+    - Add `StreetAddress` as subclass of `PostalAddress`
+    - Defined super-property `hasAddress` (and inverse `isAddressOf`)
+    - Replaced `hasStreetAddress` with `hasPhysicalAddress` (what a building, park, parking lot have), and
+      `streetAddressOf` with `isPhysicalAddressOf`.
+    - Clarified definition of `hasCommunicationAddress`, added domain (`Person U Organization`).
 
 ### Minor Updates
 

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -15,7 +15,7 @@ Release 10.0.0
     - Deleted classes `gist:OrdinalCollection` and `gist:OrdinalMember`
 - Changes to and affecting `gist:Person`, as per issue [#136](https://github.com/semanticarts/gist/issues/136):
     - Removed `owl:someValuesFrom gist:name` restriction from `gist:Person`.
-    - Made `gist:hasBirthDate` a sub-property of `gist:start` rather than `gist:actualStart`.
+    - Made `gist:hasBirthDate` a subproperty of `gist:start` rather than `gist:actualStart`.
 - Refactored the way network connections are modeled per issue [#126](<https://github.com/semanticarts/gist/issues/126>):
     - `networkConnection`, `hasFromNode` and `hasToNode` have been renamed to `links`, `linksFrom` and `linksTo`, respectively.
     - Added a restriction on `NetworkLink` that it must have exactly 2 links.
@@ -25,8 +25,9 @@ Release 10.0.0
 - Modified classes and properties related to street addresses as per issue [#483](<https://github.com/semanticarts/gist/issues/483>):
     - Removed `BuildingAddress`.
     - Added `StreetAddress` as subclass of `PostalAddress`.
-    - Replaced `hasStreetAddress` with the more general `hasAddress`. Removed `streetAddressOf`. 
-    - Clarified the definition of `hasCommunicationAddress` (which is now a sub-property of `hasAddress`,
+    - Replaced `hasStreetAddress` with the more general `hasAddress`. Removed `streetAddressOf`.
+    - Removed `communicationAddressOf` in a general effort to trim unused inverse properties.
+    - Clarified the definition of `hasCommunicationAddress` (which is now a subproperty of `hasAddress`),
       added domain (`Person U Organization`).
 
 ### Minor Updates
@@ -39,7 +40,7 @@ Release 10.0.0
 
 ### Patch Updates
 - Updated annotations for `basedOn` and `basisFor` properties. Issue [#139](https://github.com/semanticarts/gist/issues/139)
-- `hasDirectSubCategory` is now a sub-property of `hasSubCategory`, as it was always supposed to be.  Issue [#481](https://github.com/semanticarts/gist/issues/481)
+- `hasDirectSubCategory` is now a subproperty of `hasSubCategory`, as it was always supposed to be.  Issue [#481](https://github.com/semanticarts/gist/issues/481)
 - Clarified the definition of `ContemporaneousEvent`. Issue [#174](<https://github.com/semanticarts/gist/issues/174>).
 
 
@@ -337,7 +338,7 @@ Primarily fixes minor errors like typos in our gist 7.0 release.
 
 Below is a brief summary of the changes that have semantic import from an inference perspective (axiom added, removed, changed, etc.) or that are backward incompatible.
 
-- Made `gist:uniqueText` a sub-property of `gist:containedText`.
+- Made `gist:uniqueText` a subproperty of `gist:containedText`.
 - Added `gist:Agreement` to range of `gist:governs`.
 - Changed `gist:prevent`, `gist:allow` and `gist:require` to `gist:prevents`, `gist:allows`, and `gist:requires`.
 - Changed restriction on `gist:Offer` to use `gist:hasDirectPart some gist:CatalogItem`.

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -23,12 +23,11 @@ Release 10.0.0
 - Extended the range of `fromPlace`/`toPlace` to include `gist:Address` in addition to `gist:Place`.
   Issue [#392](<https://github.com/semanticarts/gist/issues/392>).
 - Modified classes and properties related to street addresses as per issue [#483](<https://github.com/semanticarts/gist/issues/483>):
-    - Removed `BuildingAddress`
-    - Add `StreetAddress` as subclass of `PostalAddress`
-    - Defined super-property `hasAddress` (and inverse `isAddressOf`)
-    - Replaced `hasStreetAddress` with `hasPhysicalAddress` (what a building, park, parking lot have), and
-      `streetAddressOf` with `isPhysicalAddressOf`.
-    - Clarified definition of `hasCommunicationAddress`, added domain (`Person U Organization`).
+    - Removed `BuildingAddress`.
+    - Added `StreetAddress` as subclass of `PostalAddress`.
+    - Replaced `hasStreetAddress` with the more general `hasAddress`. Removed `streetAddressOf`. 
+    - Clarified the definition of `hasCommunicationAddress` (which is now a sub-property of `hasAddress`,
+      added domain (`Person U Organization`).
 
 ### Minor Updates
 

--- a/gistCore.ttl
+++ b/gistCore.ttl
@@ -2243,10 +2243,10 @@ gist:Specification
 gist:StreetAddress
 	a owl:Class ;
 	rdfs:subClassOf gist:PostalAddress ;
-	skos:definition "An address which you can find in the physical world."^^xsd:string ;
-	skos:example "The street address of a building, a park or an empty lot."^^xsd:string ;
+	skos:definition "An address which references a fixed location in the physical world."^^xsd:string ;
+	skos:example "The street address of a building, a park, campground, or an empty lot."^^xsd:string ;
 	skos:prefLabel "Street Address"^^xsd:string ;
-	skos:scopeNote "Unlike the superclass, this does not include pseudo-addresses such as PO Box or FPO code."^^xsd:string ;
+	skos:scopeNote "This excludes addresses not associated with a fixed location, such as a PO box or FPO code."^^xsd:string ;
 	.
 
 gist:System
@@ -3163,6 +3163,7 @@ gist:hasAddress
 	a owl:ObjectProperty ;
 	rdfs:range gist:Address ;
 	skos:definition "Relates the subject to its physical or virtual address."^^xsd:string ;
+	skos:example "The street address of a building; the email address of a person."^^xsd:string ;
 	skos:prefLabel "has address"^^xsd:string ;
 	.
 
@@ -3205,7 +3206,7 @@ gist:hasCommunicationAddress
 		) ;
 	] ;
 	rdfs:range gist:Address ;
-	skos:definition "A location where a person or organization can receive messages including postal addresses, fax numbers, phone numbers, email, web site, etc."^^xsd:string ;
+	skos:definition "Relates a Person or Organization to where they can receive messages, including postal addresses, fax numbers, phone numbers, email, web site, etc."^^xsd:string ;
 	skos:prefLabel "has communication address"^^xsd:string ;
 	.
 
@@ -3364,14 +3365,6 @@ gist:hasParty
 	skos:prefLabel "has party"^^xsd:string ;
 	.
 
-gist:hasPhysicalAddress
-	a owl:ObjectProperty ;
-	rdfs:subPropertyOf gist:hasAddress ;
-	rdfs:range gist:StreetAddress ;
-	skos:definition "A place that can be found on a map, has geo coordinates; you could live or work there."^^xsd:string ;
-	skos:prefLabel "has physical address"^^xsd:string ;
-	.
-
 gist:hasPhysicalLocation
 	a
 		owl:ObjectProperty ,
@@ -3481,29 +3474,6 @@ gist:identifies
 		;
 	skos:definition "The thing the identifier refers to."^^xsd:string ;
 	skos:prefLabel "identifies"^^xsd:string ;
-	.
-
-gist:isAddressOf
-	a owl:ObjectProperty ;
-	owl:inverseOf gist:hasAddress ;
-	skos:definition "Whose address is this"^^xsd:string ;
-	skos:prefLabel "is address of"^^xsd:string ;
-	.
-
-gist:isCommunicationAddressOf
-	a owl:ObjectProperty ;
-	rdfs:subPropertyOf gist:isAddressOf ;
-	owl:inverseOf gist:hasCommunicationAddress ;
-	skos:definition "Whose communication address is this"^^xsd:string ;
-	skos:prefLabel "communication address of"^^xsd:string ;
-	.
-
-gist:isPhysicalAddressOf
-	a owl:ObjectProperty ;
-	rdfs:subPropertyOf gist:isAddressOf ;
-	owl:inverseOf gist:hasPhysicalAddress ;
-	skos:definition "Whose physical address is this"^^xsd:string ;
-	skos:prefLabel "is physical address of"^^xsd:string ;
 	.
 
 gist:lastModifiedOn

--- a/gistCore.ttl
+++ b/gistCore.ttl
@@ -3186,7 +3186,7 @@ gist:hasCommunicationAddress
 		) ;
 	] ;
 	rdfs:range gist:Address ;
-	skos:definition "A location where a person or organiztion can receive messages including postal addresses, fax numbers, phone numbers, email, web site, etc."^^xsd:string ;
+	skos:definition "A location where a person or organization can receive messages including postal addresses, fax numbers, phone numbers, email, web site, etc."^^xsd:string ;
 	skos:prefLabel "has communication address"^^xsd:string ;
 	.
 
@@ -3355,7 +3355,6 @@ gist:hasPhysicalAddress
 	a owl:ObjectProperty ;
 	rdfs:subPropertyOf gist:hasAddress ;
 	rdfs:range gist:StreetAddress ;
-	owl:inverseOf gist:isPhysicalAddressOf ;
 	skos:definition "A place that can be found on a map, has geo coordinates; you could live or work there."^^xsd:string ;
 	skos:prefLabel "has physical address"^^xsd:string ;
 	.
@@ -3480,6 +3479,7 @@ gist:identifies
 
 gist:isAddressOf
 	a owl:ObjectProperty ;
+	owl:inverseOf gist:hasAddress ;
 	skos:definition "Whose address is this"^^xsd:string ;
 	skos:prefLabel "is address of"^^xsd:string ;
 	.
@@ -3495,6 +3495,7 @@ gist:isCommunicationAddressOf
 gist:isPhysicalAddressOf
 	a owl:ObjectProperty ;
 	rdfs:subPropertyOf gist:isAddressOf ;
+	owl:inverseOf gist:hasPhysicalAddress ;
 	skos:definition "Whose physical address is this"^^xsd:string ;
 	skos:prefLabel "is physical address of"^^xsd:string ;
 	.

--- a/gistCore.ttl
+++ b/gistCore.ttl
@@ -189,20 +189,6 @@ gist:Building
 	skos:prefLabel "Building"^^xsd:string ;
 	.
 
-gist:BuildingAddress
-	a owl:Class ;
-	rdfs:subClassOf
-		gist:Address ,
-		[
-			a owl:Restriction ;
-			owl:onProperty gist:streetAddressOf ;
-			owl:someValuesFrom gist:Building ;
-		]
-		;
-	skos:definition "An address to which you can send mail, or that you could find in the physical world."^^xsd:string ;
-	skos:prefLabel "Building Address"^^xsd:string ;
-	.
-
 gist:BundledCatalogItem
 	a owl:Class ;
 	owl:equivalentClass [
@@ -2233,6 +2219,15 @@ gist:Specification
 	skos:prefLabel "Specification"^^xsd:string ;
 	.
 
+gist:StreetAddress
+	a owl:Class ;
+	rdfs:subClassOf gist:PostalAddress ;
+	skos:definition "An address which you can find in the physical world."^^xsd:string ;
+	skos:example "The street address of a building, a park or an empty lot."^^xsd:string ;
+	skos:prefLabel "Street Address"^^xsd:string ;
+	skos:scopeNote "Unlike the superclass, this does not include pseudo-addresses such as PO Box or FPO code."^^xsd:string ;
+	.
+
 gist:System
 	a owl:Class ;
 	owl:equivalentClass [
@@ -2879,13 +2874,6 @@ gist:characterizedAs
 	skos:prefLabel "characterized as"^^xsd:string ;
 	.
 
-gist:communicationAddressOf
-	a owl:ObjectProperty ;
-	owl:inverseOf gist:hasCommunicationAddress ;
-	skos:definition "Whose address is this"^^xsd:string ;
-	skos:prefLabel "communication address of"^^xsd:string ;
-	.
-
 gist:conformsTo
 	a owl:ObjectProperty ;
 	rdfs:range gist:Intention ;
@@ -3152,6 +3140,13 @@ gist:governs
 	skos:prefLabel "governs"^^xsd:string ;
 	.
 
+gist:hasAddress
+	a owl:ObjectProperty ;
+	rdfs:range gist:Address ;
+	skos:definition "Relates the subject to its physical or virtual address."^^xsd:string ;
+	skos:prefLabel "has address"^^xsd:string ;
+	.
+
 gist:hasAltitude
 	a owl:ObjectProperty ;
 	rdfs:domain gist:GeoPoint ;
@@ -3182,8 +3177,16 @@ gist:hasBirthDate
 
 gist:hasCommunicationAddress
 	a owl:ObjectProperty ;
+	rdfs:subPropertyOf gist:hasAddress ;
+	rdfs:domain [
+		a owl:Class ;
+		owl:unionOf (
+			gist:Person
+			gist:Organization
+		) ;
+	] ;
 	rdfs:range gist:Address ;
-	skos:definition "Points to a general class of places you can send messages including postal addresses, fax numbers, phone numbers, email, web site, etc."^^xsd:string ;
+	skos:definition "A location where a person or organiztion can receive messages including postal addresses, fax numbers, phone numbers, email, web site, etc."^^xsd:string ;
 	skos:prefLabel "has communication address"^^xsd:string ;
 	.
 
@@ -3348,6 +3351,15 @@ gist:hasParty
 	skos:prefLabel "has party"^^xsd:string ;
 	.
 
+gist:hasPhysicalAddress
+	a owl:ObjectProperty ;
+	rdfs:subPropertyOf gist:hasAddress ;
+	rdfs:range gist:StreetAddress ;
+	owl:inverseOf gist:isPhysicalAddressOf ;
+	skos:definition "A place that can be found on a map, has geo coordinates; you could live or work there."^^xsd:string ;
+	skos:prefLabel "has physical address"^^xsd:string ;
+	.
+
 gist:hasPhysicalLocation
 	a
 		owl:ObjectProperty ,
@@ -3373,14 +3385,6 @@ gist:hasStandardUnit
 	rdfs:range gist:CoherentUnit ;
 	skos:definition "For a complex unit refers to a unit that has all the component parts in SI"^^xsd:string ;
 	skos:prefLabel "has standard unit"^^xsd:string ;
-	.
-
-gist:hasStreetAddress
-	a owl:ObjectProperty ;
-	rdfs:range gist:BuildingAddress ;
-	owl:inverseOf gist:streetAddressOf ;
-	skos:definition "A place that can be found on a map, has geo coordinates; you could live or work there."^^xsd:string ;
-	skos:prefLabel "has street address"^^xsd:string ;
 	.
 
 gist:hasSubCategory
@@ -3472,6 +3476,27 @@ gist:identifies
 		;
 	skos:definition "The thing the identifier refers to."^^xsd:string ;
 	skos:prefLabel "identifies"^^xsd:string ;
+	.
+
+gist:isAddressOf
+	a owl:ObjectProperty ;
+	skos:definition "Whose address is this"^^xsd:string ;
+	skos:prefLabel "is address of"^^xsd:string ;
+	.
+
+gist:isCommunicationAddressOf
+	a owl:ObjectProperty ;
+	rdfs:subPropertyOf gist:isAddressOf ;
+	owl:inverseOf gist:hasCommunicationAddress ;
+	skos:definition "Whose communication address is this"^^xsd:string ;
+	skos:prefLabel "communication address of"^^xsd:string ;
+	.
+
+gist:isPhysicalAddressOf
+	a owl:ObjectProperty ;
+	rdfs:subPropertyOf gist:isAddressOf ;
+	skos:definition "Whose physical address is this"^^xsd:string ;
+	skos:prefLabel "is physical address of"^^xsd:string ;
 	.
 
 gist:lastModifiedOn
@@ -3788,12 +3813,6 @@ gist:start
 	rdfs:range gist:TimeInstant ;
 	skos:definition "Connects the subject to its start time."^^xsd:string ;
 	skos:prefLabel "start"^^xsd:string ;
-	.
-
-gist:streetAddressOf
-	a owl:ObjectProperty ;
-	skos:definition "Whose street address is this"^^xsd:string ;
-	skos:prefLabel "street address of"^^xsd:string ;
 	.
 
 gist:subTaskOf

--- a/validation_queries/property_type_construct.rq
+++ b/validation_queries/property_type_construct.rq
@@ -1,0 +1,26 @@
+prefix skos: <http://www.w3.org/2004/02/skos/core#>
+prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+prefix sh: <http://www.w3.org/ns/shacl#>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+prefix gist: <https://ontologies.semanticarts.com/gist/>
+
+CONSTRUCT {
+    ?report a sh:ValidationReport ;
+        sh:conforms false ;
+        sh:result [ a sh:ValidationResult ;
+                sh:focusNode ?focus ;
+                sh:resultMessage ?error ;
+                sh:resultPath ?ref_prop ;
+                sh:resultSeverity sh:Violation ;
+                sh:value ?ref_type ] .
+}
+WHERE {
+  VALUES ?focus_type { owl:ObjectProperty owl:DatatypeProperty owl:AnnotationProperty}
+  VALUES (?ref_prop ?message) { (rdfs:subPropertyOf "Super-property") (owl:inverseOf "Inverse property") }
+  ?focus a ?focus_type; ?ref_prop ?ref .
+  ?ref a ?ref_type .
+  FILTER (?ref_type in (owl:ObjectProperty, owl:DatatypeProperty, owl:AnnotationProperty))
+  FILTER (?focus_type != ?ref_type)
+  bind(<urn:property-vaidation-report> as ?report)
+  bind(CONCAT(?message, " ", REPLACE(STR(?ref), '^.*[/#]', ''), " must be the same type.") as ?error)
+}


### PR DESCRIPTION
I also added validation that super/inverse properties have to be the same type as the source property (i.e. ObjectProperty can't have a DatatypeProperty as a super-property). I did _not_, however, mandate that the parent or inverse are defined, in case we are referencing a property defined elsewhere. Let me know if this is something we want to enforce - it would prevent referencing an unresolved URI due to a typo. Might want to also add referential integrity checks for classes at some point (e.g. `subClassOf` or `disjointWith`).