### PR TITLE
Add missing 'target' for validation.

### DIFF
--- a/bundle.yaml
+++ b/bundle.yaml
@@ -75,6 +75,7 @@ actions:
   includes:
     - gistCore.ttl
   stopOnFail: false
+  target: '{input}/validation'
   queries:
     source: '{input}/validation_queries'
     includes:

--- a/validation_queries/property_type_construct.rq
+++ b/validation_queries/property_type_construct.rq
@@ -12,6 +12,7 @@ CONSTRUCT {
                 sh:resultMessage ?error ;
                 sh:resultPath ?ref_prop ;
                 sh:resultSeverity sh:Violation ;
+                sh:sourceConstraintComponent <urn:constraint:property-reference> ;
                 sh:value ?ref_type ] .
 }
 WHERE {


### PR DESCRIPTION
This is due to me releasing `onto-tool` v1.4.0, which has stricter syntax checking on the bundle file and found this latent issue we had. Also fixed the `CONSTRUCT` query to supply a required property of the ValidationReport.