### PR TITLE
Rename on format then rename back to avoid serialization issue.

### DIFF
--- a/bundle.yaml
+++ b/bundle.yaml
@@ -138,6 +138,17 @@ actions:
   target: "{output}"
   includes:
     - "*.ttl"
+  rename:
+    from: "(.*)\\.ttl"
+    to: "formatted_\\g<1>.ttl"
+- action: "move"
+  source: "{output}"
+  target: "{output}"
+  includes:
+    - "formatted_*.ttl"
+  rename:
+    from: "formatted_(.*)\\.ttl"
+    to: "\\g<1>.ttl"
 - action: "transform"
   message: "RDF/XML serialization."
   tool: "xml-serializer"


### PR DESCRIPTION
The issue introduced by the Java11-based `rdf-toolkit` is the inability to serialize in place - the input and output files have to be different. For some reason I did not catch this when testing, and we have no automated sanity test in place to make sure the formatted output is similar to the input - that's a deficiency to consider.

Regardless, I modified the build to rename the Turtle files during formatting, then move them back. No need to do for any of the others, since they have different extensions, so they are not overwritten.