### PR TITLE
Clarify restrictions on OrderedMember

### DIFF
--- a/gistCore.ttl
+++ b/gistCore.ttl
@@ -1777,12 +1777,12 @@ gist:OrderedMember
 					[
 						a owl:Restriction ;
 						owl:onProperty gist:precedesDirectly ;
-						owl:someValuesFrom owl:Thing ;
+						owl:someValuesFrom gist:OrderedMember ;
 					]
 					[
 						a owl:Restriction ;
 						owl:onProperty gist:followsDirectly ;
-						owl:someValuesFrom owl:Thing ;
+						owl:someValuesFrom gist:OrderedMember ;
 					]
 					[
 						a owl:Restriction ;


### PR DESCRIPTION
This change clarifies the meaning of the restriction, though it is strictly speaking logically redundant: since only `OrderedMember`s belong to `OrderedCollection`s, precedence would be only in relation to other `OrderedMember`s. There's an edge case counterexample where an `OrderedMember` is asserted to precede or follow something outside the `OrderedCollection`, but it's hard to see how that situation would occur. At any rate, this creates greater clarity.