### PR TITLE
Generalize the properties :numerator, :denominator, :multiplier, and :multiplicand. Fixes #160. 

### DIFF
--- a/gistCore.ttl
+++ b/gistCore.ttl
@@ -3193,16 +3193,12 @@ gist:hasMember
 
 gist:hasMultiplicand
 	a owl:ObjectProperty ;
-	rdfs:domain gist:ProductUnit ;
-	rdfs:range gist:UnitOfMeasure ;
 	skos:definition "Relates a ProductUnit such as square mile to the second of two units multiplied together (e.g. mile)."^^xsd:string ;
 	skos:prefLabel "has multiplicand"^^xsd:string ;
 	.
 
 gist:hasMultiplier
 	a owl:ObjectProperty ;
-	rdfs:domain gist:ProductUnit ;
-	rdfs:range gist:UnitOfMeasure ;
 	skos:definition "Relates a ProductUnit such as square mile to the first of two units multiplied together (e.g. mile)"^^xsd:string ;
 	skos:prefLabel "has multiplier"^^xsd:string ;
 	.


### PR DESCRIPTION
```markdown
Release notes gist x.x.x
-----

### Major Updates
- Removed domain and range for `gist:hasNumerator`, `gist:hasDenominator`, `gist:hasMultiplier`, and `gist:hasMultiplicand`. Issue [#160](https://github.com/semanticarts/gist/issues/160). 

```