### PR TITLE
Deprecated gist:hasOrderedMember

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -13,7 +13,7 @@ Release X.x.x
 - Updated annotations for coherent unit classes, per issue [#146](https://github.com/semanticarts/gist/issues/146).
 - Added labels to gist instances, per issue [#370](https://github.com/semanticarts/gist/issues/370).
 - Added definitions for unit of measure instances per issue [#526](https://github.com/semanticarts/gist/issues/526).
-- Deprecated propery `gist:hasOrderedMember`. `gist:hasMember` should be used instead. Issue [#540](https://github.com/semanticarts/gist/issues/540).
+- Deprecated property `gist:hasOrderedMember`. `gist:hasMember` should be used instead. Issue [#540](https://github.com/semanticarts/gist/issues/540).
   
 Import URL: <https://ontologies.semanticarts.com/o/gistCoreX.x.x>.
 

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -6,16 +6,16 @@ Release X.x.x
 
 ### Minor Updates
 
-- Added unit symbols for unit instances instances per issue [#579](https://github.com/semanticarts/gist/issues/579). 
+- Added unit symbols for unit instances instances per issue [#579](https://github.com/semanticarts/gist/issues/579).
 
 ### Patch Updates
 
 - Updated annotations for coherent unit classes, per issue [#146](https://github.com/semanticarts/gist/issues/146).
 - Added labels to gist instances, per issue [#370](https://github.com/semanticarts/gist/issues/370).
-- Added definitions for unit of measure instances per issue [#526](https://github.com/semanticarts/gist/issues/526). 
-
+- Added definitions for unit of measure instances per issue [#526](https://github.com/semanticarts/gist/issues/526).
+- Deprecated propery `gist:hasOrderedMember`. `gist:hasMember` should be used instead. Issue [#540](https://github.com/semanticarts/gist/issues/540).
+  
 Import URL: <https://ontologies.semanticarts.com/o/gistCoreX.x.x>.
-
 
 Release 10.0.0
 -----

--- a/gistCore.ttl
+++ b/gistCore.ttl
@@ -3286,18 +3286,6 @@ gist:hasOffsetToUniversal
 	skos:prefLabel "has offset to universal"^^xsd:string ;
 	.
 
-gist:hasOrderedMember
-	a
-		owl:ObjectProperty ,
-		owl:InverseFunctionalProperty
-		;
-	rdfs:subPropertyOf gist:hasMember ;
-	rdfs:range gist:OrderedMember ;
-	skos:definition "Relates an ordered collection to an ordered member that belongs to it."^^xsd:string ;
-	skos:prefLabel "has ordered member"^^xsd:string ;
-	skos:scopeNote "This property is inverse functional because no ordered member can be in more than one ordered collection."^^xsd:string ;
-	.
-
 gist:hasPart
 	a
 		owl:ObjectProperty ,

--- a/gistDeprecated.ttl
+++ b/gistDeprecated.ttl
@@ -1,0 +1,32 @@
+# imports: https://ontologies.semanticarts.com/o/gistCoreX.x.x
+
+@prefix gist: <https://ontologies.semanticarts.com/gist/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<https://ontologies.semanticarts.com/o/gistDeprecated>
+	a owl:Ontology ;
+	owl:imports <https://ontologies.semanticarts.com/o/gistCoreX.x.x> ;
+	owl:versionIRI <https://ontologies.semanticarts.com/o/gistDeprecatedX.x.x> ;
+	skos:definition "Concepts that have been deprecated since the last major release (in this case, 10.0.0)."^^xsd:string ;
+	skos:prefLabel "gistDeprecated"^^xsd:string ;
+	skos:scopeNote "This file will be removed on the next major release."^^xsd:string ;
+	gist:license "https://creativecommons.org/licenses/by-sa/3.0/"^^xsd:string ;
+	.
+
+gist:hasOrderedMember
+	a
+		owl:ObjectProperty ,
+		owl:InverseFunctionalProperty
+		;
+	rdfs:subPropertyOf gist:hasMember ;
+	rdfs:range gist:OrderedMember ;
+	owl:deprecated "true"^^xsd:boolean ;
+	skos:definition "Relates an ordered collection to an ordered member that belongs to it."^^xsd:string ;
+	skos:prefLabel "has ordered member"^^xsd:string ;
+	skos:scopeNote "This property is inverse functional because no ordered member can be in more than one ordered collection."^^xsd:string ;
+	.
+

--- a/migration/v10.0/detect_removed.rq
+++ b/migration/v10.0/detect_removed.rq
@@ -34,6 +34,7 @@ WHERE {
                 gist:getter
                 gist:giver
                 gist:hasA
+                gist:hasOrdinalMember
                 gist:localDate
                 gist:localDateTime
                 gist:of

--- a/migration/v10.0/detect_removed.rq
+++ b/migration/v10.0/detect_removed.rq
@@ -34,7 +34,7 @@ WHERE {
                 gist:getter
                 gist:giver
                 gist:hasA
-                gist:hasOrdinalMember
+                gist:hasOrderedMember
                 gist:localDate
                 gist:localDateTime
                 gist:of


### PR DESCRIPTION
This property should have been removed as per issue 540. While the other changes proposed in that issue were implemented, the property itself was not removed.