### PR TITLE
Change skos:definition of Task to define it as an Event, not as a Task.

### DIFF
--- a/gistCore.ttl
+++ b/gistCore.ttl
@@ -2328,7 +2328,7 @@ gist:Task
 			]
 		) ;
 	] ;
-	skos:definition "A task which has been defined and either scheduled or accomplished, or both."^^xsd:string ;
+	skos:definition "An event which has been defined and either scheduled or accomplished, or both."^^xsd:string ;
 	skos:prefLabel "Task"^^xsd:string ;
 	.
 


### PR DESCRIPTION
Patch for a one-word change in the skos definition.