### PR TITLE
Update minimum Java version needed to run rdf-toolkit

### DIFF
--- a/tools/pre-commit
+++ b/tools/pre-commit
@@ -56,7 +56,7 @@ function findJava() {
     whichJava="${java_home}/bin/java"
   else
     log_error "Could not find java in your RDF_TOOLKIT_JAVA_HOME or JAVA_HOME: ${java_home}"
-    log_error "Please set RDF_TOOLKIT_JAVA_HOME or JAVA_HOME to point to a Java 7 or later installation."
+    log_error "Please set RDF_TOOLKIT_JAVA_HOME or JAVA_HOME to point to a Java 11 or later installation."
     return 1
   fi
   log "whichJava =" $whichJava


### PR DESCRIPTION
Minimum version number is now 11, not 7.