### PR TITLE
Add predicates with year precision. Fixes #388.

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -6,10 +6,10 @@ Release 11.0.0
 
 ### Major Updates
 
-- Implemented new time model based on datatype properties rather than `TimeInstant`. Issue [#499](https://github.com/semanticarts/gist/issues/499).
-    - Deleted class `TimeInstant` and its subclasses. This class was previously used to materialize a point in time with different precisions (year, day, minute, system time), a time zone, a local and UTC value, and so on. Object properties were used to connect something to an instance of `TimeInstant`, specifying different relationships such as start and end, planned vs actual.
-    - Defined a top-level datatype property `atDateTime`, neutral as to start/end, planned/actual, and precision (year, day, minute, microsecond). Replaced existing object properties to a hierarchy of subproperties of `atDateTime`, retaining distinctions between start and end, planned vs actual, and precisions.
-    - New predicates with year precision were added alongside the existing day, minute, and milli-/microsecond precisions. Issue [#388](https://github.com/semanticarts/gist/issues/388).
+- Implemented new time model based on datatype properties rather than `TimeInstant`. Issues [#499](https://github.com/semanticarts/gist/issues/499), [#388](https://github.com/semanticarts/gist/issues/388). 
+    - Deleted class `TimeInstant` and its subclasses. This class was previously used to materialize a point in time with different precisions (day, minute, system time), a time zone, a local and UTC value, and so on. Object properties were used to connect something to an instance of `TimeInstant`, specifying different relationships such as start and end, planned vs actual.
+    - Defined a top-level datatype property `atDateTime`, neutral as to start/end, planned/actual, and precision (year, day, minute, microsecond).
+    - Replaced existing object properties with a hierarchy of subproperties of `atDateTime`, retaining distinctions between start and end, planned vs actual, and precisions. Included adding new predicates with year precision alongside the existing day, minute, and milli-/microsecond precisions.
     - Renamed `ContemporaneousEvent` to `ContemporaryEvent`.
 - Removed property  `gist:hasOrderedMember`. `gist:hasMember` should be used instead. Issue [#540](https://github.com/semanticarts/gist/issues/540).
 - Removed domain and range constraints from `gist:requires`. Issue [#183](https://github.com/semanticarts/gist/issues/183).

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -7,8 +7,9 @@ Release 11.0.0
 ### Major Updates
 
 - Implemented new time model based on datatype properties rather than `TimeInstant`. Issue [#499](https://github.com/semanticarts/gist/issues/499).
-    - Deleted class `TimeInstant` and its subclasses. This class was previously used to materialize a point in time with different precisions (day, minute, system time), a time zone, a local and UTC value, and so on. Object properties were used to connect something to an instance of `TimeInstant`, specifying different relationships such as start and end, planned vs actual.
-    - Defined a top-level datatype property `atDateTime`, neutral as to start/end, planned/actual, and precision (day, minute, microsecond). Replaced existing object properties to a hierarchy of subproperties of `atDateTime`, retaining distinctions between start and end, planned vs actual, and precisions.
+    - Deleted class `TimeInstant` and its subclasses. This class was previously used to materialize a point in time with different precisions (year, day, minute, system time), a time zone, a local and UTC value, and so on. Object properties were used to connect something to an instance of `TimeInstant`, specifying different relationships such as start and end, planned vs actual.
+    - Defined a top-level datatype property `atDateTime`, neutral as to start/end, planned/actual, and precision (year, day, minute, microsecond). Replaced existing object properties to a hierarchy of subproperties of `atDateTime`, retaining distinctions between start and end, planned vs actual, and precisions.
+    - New predicates with year precision were added alongside the existing day, minute, and milli-/microsecond precisions. Issue [#388](https://github.com/semanticarts/gist/issues/388).
     - Renamed `ContemporaneousEvent` to `ContemporaryEvent`.
 - Removed property  `gist:hasOrderedMember`. `gist:hasMember` should be used instead. Issue [#540](https://github.com/semanticarts/gist/issues/540).
 - Removed domain and range constraints from `gist:requires`. Issue [#183](https://github.com/semanticarts/gist/issues/183).

--- a/gistCore.ttl
+++ b/gistCore.ttl
@@ -2727,6 +2727,16 @@ gist:actualEndMinute
 	skos:scopeNote "Used for things like meetings and time card entries, where the hour and minute are important. Recommended usage is to zero out the seconds and microseconds to avoid spurious precision."^^xsd:string ;
 	.
 
+gist:actualEndYear
+	a owl:DatatypeProperty ;
+	rdfs:subPropertyOf gist:actualEndDateTime ;
+	rdfs:range xsd:dateTime ;
+	skos:definition "The actual date that something ended, with precision of one year."^^xsd:string ;
+	skos:example "'2021-00-00T00:00:00-6:00'^^xsd:dateTime"^^xsd:string ;
+	skos:prefLabel "actual end year"^^xsd:string ;
+	skos:scopeNote "Used for things where the precision of a year is sufficient. Recommended usage is to zero out the month through microseconds to avoid spurious precision."^^xsd:string ;
+	.
+
 gist:actualStartDate
 	a owl:DatatypeProperty ;
 	rdfs:subPropertyOf gist:actualStartDateTime ;
@@ -2764,6 +2774,16 @@ gist:actualStartMinute
 	skos:example "'2021-06-01T08:32:00-6:00'^^xsd:dateTime"^^xsd:string ;
 	skos:prefLabel "actual start minute"^^xsd:string ;
 	skos:scopeNote "Used for things like meetings and time card entries, where the hour and minute are important. Recommended usage is to zero out the seconds and microseconds to avoid spurious precision."^^xsd:string ;
+	.
+
+gist:actualStartYear
+	a owl:DatatypeProperty ;
+	rdfs:subPropertyOf gist:actualEndDateTime ;
+	rdfs:range xsd:dateTime ;
+	skos:definition "The actual date that something started, with precision of one year."^^xsd:string ;
+	skos:example "'2021-00-00T00:00:00-6:00'^^xsd:dateTime"^^xsd:string ;
+	skos:prefLabel "actual start year"^^xsd:string ;
+	skos:scopeNote "Used for things where the precision of a year is sufficient. Recommended usage is to zero out the month through microseconds to avoid spurious precision."^^xsd:string ;
 	.
 
 gist:affects
@@ -3708,6 +3728,16 @@ gist:plannedEndMinute
 	skos:scopeNote "Used for things like meetings and time card entries, where the hour and minute are important. Recommended usage is to zero out the seconds and microseconds to avoid spurious precision.Typically a planned date is in the future when first captured, but when tasks run late, we leave the plan where it was and compare it to the actual."^^xsd:string ;
 	.
 
+gist:plannedEndYear
+	a owl:DatatypeProperty ;
+	rdfs:subPropertyOf gist:plannedEndDateTime ;
+	rdfs:range xsd:dateTime ;
+	skos:definition "The date that something is or was planned to end, with precision of one year."^^xsd:string ;
+	skos:example "'2021-00-00T00:00:00-6:00'^^xsd:dateTime"^^xsd:string ;
+	skos:prefLabel "planned end year"^^xsd:string ;
+	skos:scopeNote "Used for anything with a planned end date where precision of one year is sufficient. Typically a planned date is in the future when first captured, but when tasks run late, we leave the plan where it was and compare it to the actual. Recommended usage is to zero out the months through microseconds to avoid spurious precision."^^xsd:string ;
+	.
+
 gist:plannedStartDate
 	a owl:DatatypeProperty ;
 	rdfs:subPropertyOf gist:plannedStartDateTime ;
@@ -3738,6 +3768,19 @@ gist:plannedStartMinute
 	skos:example "'2021-06-01T08:32:00-6:00'^^xsd:dateTime"^^xsd:string ;
 	skos:prefLabel "planned start minute"^^xsd:string ;
 	skos:scopeNote "Used for things like meetings and time card entries, where the hour and minute are important. Typically a planned date is in the future when first captured, but when tasks run late, we leave the plan where it was and compare it to the actual. Recommended usage is to zero out the seconds and microseconds to avoid spurious precision."^^xsd:string ;
+	.
+
+gist:plannedStartYear
+	a owl:DatatypeProperty ;
+	rdfs:subPropertyOf gist:plannedStartDateTime ;
+	rdfs:range xsd:dateTime ;
+	skos:definition "The date that something is or was planned to start, with precision of one year."^^xsd:string ;
+	skos:example
+		"'2021-00-00T00:00:00-6:00'^^xsd:dateTime"^^xsd:string ,
+		"The automobile manufacturer announced that its full line-up would include only electric cars starting in 2035."^^xsd:string
+		;
+	skos:prefLabel "planned start year"^^xsd:string ;
+	skos:scopeNote "Used for anything with a planned start date where precision of one year is sufficient, such as . Typically a planned date is in the future when first captured, but when tasks run late, we leave the plan where it was and compare it to the actual. Recommended usage is to zero out the months through microseconds to avoid spurious precision."^^xsd:string ;
 	.
 
 gist:precedes

--- a/gistCore.ttl
+++ b/gistCore.ttl
@@ -2781,7 +2781,7 @@ gist:actualStartMinute
 
 gist:actualStartYear
 	a owl:DatatypeProperty ;
-	rdfs:subPropertyOf gist:actualEndDateTime ;
+	rdfs:subPropertyOf gist:actualStartDateTime ;
 	rdfs:range xsd:dateTime ;
 	skos:definition "The actual date that something started, with precision of one year."^^xsd:string ;
 	skos:example

--- a/gistCore.ttl
+++ b/gistCore.ttl
@@ -2732,7 +2732,10 @@ gist:actualEndYear
 	rdfs:subPropertyOf gist:actualEndDateTime ;
 	rdfs:range xsd:dateTime ;
 	skos:definition "The actual date that something ended, with precision of one year."^^xsd:string ;
-	skos:example "'2021-00-00T00:00:00-6:00'^^xsd:dateTime"^^xsd:string ;
+	skos:example
+		"'2021-00-00T00:00:00-6:00'^^xsd:dateTime"^^xsd:string ,
+		"The tenure of the previous chairman of the board ended in 2021."^^xsd:string
+		;
 	skos:prefLabel "actual end year"^^xsd:string ;
 	skos:scopeNote "Used for things where the precision of a year is sufficient. Recommended usage is to zero out the month through microseconds to avoid spurious precision."^^xsd:string ;
 	.
@@ -2781,7 +2784,10 @@ gist:actualStartYear
 	rdfs:subPropertyOf gist:actualEndDateTime ;
 	rdfs:range xsd:dateTime ;
 	skos:definition "The actual date that something started, with precision of one year."^^xsd:string ;
-	skos:example "'2021-00-00T00:00:00-6:00'^^xsd:dateTime"^^xsd:string ;
+	skos:example
+		"'2021-00-00T00:00:00-6:00'^^xsd:dateTime"^^xsd:string ,
+		"The tenure of the current chairman of the board began in 2021."^^xsd:string
+		;
 	skos:prefLabel "actual start year"^^xsd:string ;
 	skos:scopeNote "Used for things where the precision of a year is sufficient. Recommended usage is to zero out the month through microseconds to avoid spurious precision."^^xsd:string ;
 	.
@@ -3733,7 +3739,10 @@ gist:plannedEndYear
 	rdfs:subPropertyOf gist:plannedEndDateTime ;
 	rdfs:range xsd:dateTime ;
 	skos:definition "The date that something is or was planned to end, with precision of one year."^^xsd:string ;
-	skos:example "'2021-00-00T00:00:00-6:00'^^xsd:dateTime"^^xsd:string ;
+	skos:example
+		"'2021-00-00T00:00:00-6:00'^^xsd:dateTime"^^xsd:string ,
+		"The automobile manufacturer announced that it will stop producing gas-powered vehicles in 2035."^^xsd:string
+		;
 	skos:prefLabel "planned end year"^^xsd:string ;
 	skos:scopeNote "Used for anything with a planned end date where precision of one year is sufficient. Typically a planned date is in the future when first captured, but when tasks run late, we leave the plan where it was and compare it to the actual. Recommended usage is to zero out the months through microseconds to avoid spurious precision."^^xsd:string ;
 	.
@@ -3777,7 +3786,7 @@ gist:plannedStartYear
 	skos:definition "The date that something is or was planned to start, with precision of one year."^^xsd:string ;
 	skos:example
 		"'2021-00-00T00:00:00-6:00'^^xsd:dateTime"^^xsd:string ,
-		"The automobile manufacturer announced that its full line-up would include only electric cars starting in 2035."^^xsd:string
+		"The automobile manufacturer announced that its full line-up will include only electric cars starting in 2035."^^xsd:string
 		;
 	skos:prefLabel "planned start year"^^xsd:string ;
 	skos:scopeNote "Used for anything with a planned start date where precision of one year is sufficient, such as . Typically a planned date is in the future when first captured, but when tasks run late, we leave the plan where it was and compare it to the actual. Recommended usage is to zero out the months through microseconds to avoid spurious precision."^^xsd:string ;


### PR DESCRIPTION
Added predicates:

```
actualStartYear
actualEndYear
plannedStartYear
plannedEndYear
```