### PR TITLE
Correct notes on year-precision predicates. Fixes #652.

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -6,12 +6,12 @@ Release 11.0.0
 
 ### Major Updates
 
-- Implemented new time model based on datatype properties rather than `TimeInstant`. Issues [#499](https://github.com/semanticarts/gist/issues/499), [#388](https://github.com/semanticarts/gist/issues/388).
+- Implemented new time model based on datatype properties rather than `TimeInstant`. Issues [#499](https://github.com/semanticarts/gist/issues/499), [#388](https://github.com/semanticarts/gist/issues/388). Sample triples are provided in the release package.
     - Deleted class `TimeInstant` and its subclasses. This class was previously used to materialize a point in time with different precisions (day, minute, system time), a time zone, a local and UTC value, and so on. Object properties were used to connect something to an instance of `TimeInstant`, specifying different relationships such as start and end, planned vs actual.
     - Defined a top-level datatype property `atDateTime`, neutral as to start/end, planned/actual, and precision (year, day, minute, microsecond).
     - Replaced existing object properties with a hierarchy of subproperties of `atDateTime`, retaining distinctions between start and end, planned vs actual, and precisions.
     - Added new predicates with year precision alongside the existing day, minute, and milli-/microsecond precisions.
-    - Renamed `ContemporaneousEvent` to `ContemporaryEvent`.
+- Renamed `ContemporaneousEvent` to `ContemporaryEvent`.
 - Removed property  `gist:hasOrderedMember`. `gist:hasMember` should be used instead. Issue [#540](https://github.com/semanticarts/gist/issues/540).
 - Distinguished governments from governed geo-regions, as per issue [#215](https://github.com/semanticarts/gist/issues/215). Changes include:
     - Added classes `SubCountryGovernment`, `IntergovernmentalOrganization`, and `TreatyOrganization` as subclasses of `Organization`.

--- a/gistCore.ttl
+++ b/gistCore.ttl
@@ -2819,11 +2819,11 @@ gist:actualEndYear
 	rdfs:range xsd:dateTime ;
 	skos:definition "The actual date that something ended, with precision of one year."^^xsd:string ;
 	skos:example
-		"'2021-00-00T00:00:00-6:00'^^xsd:dateTime"^^xsd:string ,
+		"'2021-01-01T00:00:00-6:00'^^xsd:dateTime"^^xsd:string ,
 		"The tenure of the previous chairman of the board ended in 2021."^^xsd:string
 		;
 	skos:prefLabel "actual end year"^^xsd:string ;
-	skos:scopeNote "Used for things where the precision of a year is sufficient. Recommended usage is to zero out the month through microseconds to avoid spurious precision."^^xsd:string ;
+	skos:scopeNote "Used for things where the precision of a year is sufficient. Recommended usage is to zero out the hours through microseconds to avoid spurious precision. Note that it is not valid to zero out months and days, so arbitrary values must be included."^^xsd:string ;
 	.
 
 gist:actualStartDate
@@ -2871,11 +2871,11 @@ gist:actualStartYear
 	rdfs:range xsd:dateTime ;
 	skos:definition "The actual date that something started, with precision of one year."^^xsd:string ;
 	skos:example
-		"'2021-00-00T00:00:00-6:00'^^xsd:dateTime"^^xsd:string ,
+		"'2021-01-01T00:00:00-6:00'^^xsd:dateTime"^^xsd:string ,
 		"The tenure of the current chairman of the board began in 2021."^^xsd:string
 		;
 	skos:prefLabel "actual start year"^^xsd:string ;
-	skos:scopeNote "Used for things where the precision of a year is sufficient. Recommended usage is to zero out the month through microseconds to avoid spurious precision."^^xsd:string ;
+	skos:scopeNote "Used for things where the precision of a year is sufficient. Recommended usage is to zero out the hours through microseconds to avoid spurious precision. Note that it is not valid to zero out months and days, so arbitrary values must be included."^^xsd:string ;
 	.
 
 gist:affects
@@ -3817,11 +3817,11 @@ gist:plannedEndYear
 	rdfs:range xsd:dateTime ;
 	skos:definition "The date that something is or was planned to end, with precision of one year."^^xsd:string ;
 	skos:example
-		"'2021-00-00T00:00:00-6:00'^^xsd:dateTime"^^xsd:string ,
+		"'2021-01-01T00:00:00-6:00'^^xsd:dateTime"^^xsd:string ,
 		"The automobile manufacturer announced that it will stop producing gas-powered vehicles in 2035."^^xsd:string
 		;
 	skos:prefLabel "planned end year"^^xsd:string ;
-	skos:scopeNote "Used for anything with a planned end date where precision of one year is sufficient. Typically a planned date is in the future when first captured, but when tasks run late, we leave the plan where it was and compare it to the actual. Recommended usage is to zero out the months through microseconds to avoid spurious precision."^^xsd:string ;
+	skos:scopeNote "Used for anything with a planned end date where precision of one year is sufficient. Typically a planned date is in the future when first captured, but when tasks run late, we leave the plan where it was and compare it to the actual. Recommended usage is to zero out the hours through microseconds to avoid spurious precision. Note that it is not valid to zero out months and days, so arbitrary values must be included."^^xsd:string ;
 	.
 
 gist:plannedStartDate
@@ -3862,11 +3862,11 @@ gist:plannedStartYear
 	rdfs:range xsd:dateTime ;
 	skos:definition "The date that something is or was planned to start, with precision of one year."^^xsd:string ;
 	skos:example
-		"'2021-00-00T00:00:00-6:00'^^xsd:dateTime"^^xsd:string ,
+		"'2021-01-01T00:00:00-6:00'^^xsd:dateTime"^^xsd:string ,
 		"The automobile manufacturer announced that its full line-up will include only electric cars starting in 2035."^^xsd:string
 		;
 	skos:prefLabel "planned start year"^^xsd:string ;
-	skos:scopeNote "Used for anything with a planned start date where precision of one year is sufficient, such as . Typically a planned date is in the future when first captured, but when tasks run late, we leave the plan where it was and compare it to the actual. Recommended usage is to zero out the months through microseconds to avoid spurious precision."^^xsd:string ;
+	skos:scopeNote "Used for anything with a planned start date where precision of one year is sufficient, such as . Typically a planned date is in the future when first captured, but when tasks run late, we leave the plan where it was and compare it to the actual. Recommended usage is to zero out the hours through microseconds to avoid spurious precision. Note that it is not valid to zero out months and days, so arbitrary values must be included."^^xsd:string ;
 	.
 
 gist:precedes

--- a/gistCore.ttl
+++ b/gistCore.ttl
@@ -3866,7 +3866,7 @@ gist:plannedStartYear
 		"The automobile manufacturer announced that its full line-up will include only electric cars starting in 2035."^^xsd:string
 		;
 	skos:prefLabel "planned start year"^^xsd:string ;
-	skos:scopeNote "Used for anything with a planned start date where precision of one year is sufficient, such as . Typically a planned date is in the future when first captured, but when tasks run late, we leave the plan where it was and compare it to the actual. Recommended usage is to zero out the hours through microseconds to avoid spurious precision. Note that it is not valid to zero out months and days, so arbitrary values must be included."^^xsd:string ;
+	skos:scopeNote "Used for anything with a planned start date where precision of one year is sufficient. Typically a planned date is in the future when first captured, but when tasks run late, we leave the plan where it was and compare it to the actual. Recommended usage is to zero out the hours through microseconds to avoid spurious precision. Note that it is not valid to zero out months and days, so arbitrary values must be included."^^xsd:string ;
 	.
 
 gist:precedes


### PR DESCRIPTION
Datetimes with 00 for months or days violates the xsd format. Corrected example and notes.