### PR TITLE
Fixes #661: update scopenote with isIdentifiedBy

### DIFF
--- a/gistCore.ttl
+++ b/gistCore.ttl
@@ -3706,7 +3706,7 @@ gist:name
 	rdfs:range xsd:string ;
 	skos:definition "Relates an individual to a casual name."^^xsd:string ;
 	skos:prefLabel "name"^^xsd:string ;
-	skos:scopeNote "For more formal use, consider using a sub property of the object property, identifiedBy."^^xsd:string ;
+	skos:scopeNote "For more formal use, consider using a sub property of the object property, isIdentifiedBy."^^xsd:string ;
 	.
 
 gist:numericValue

--- a/gistCore.ttl
+++ b/gistCore.ttl
@@ -3704,9 +3704,8 @@ gist:longitude
 gist:name
 	a owl:DatatypeProperty ;
 	rdfs:range xsd:string ;
-	skos:definition "Relates an individual to a casual name."^^xsd:string ;
+	skos:definition "Relates an individual to (one of) its name(s)."^^xsd:string ;
 	skos:prefLabel "name"^^xsd:string ;
-	skos:scopeNote "For more formal use, consider using a sub property of the object property, isIdentifiedBy."^^xsd:string ;
 	.
 
 gist:numericValue


### PR DESCRIPTION
Fixes #661
Update scopenote on gist:name to use the correct property name that was previously updated.