### PR TITLE
Update annotations on gist:uniqueText. Fixes #577.

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -8,11 +8,12 @@ Release 11.1.0
 
 ### Patch Updates
 
-- Improved the clarity and accuracy of annotations, including definitions, examples, and scope notes, on several terms.
+- Improved the clarity and accuracy of annotations, including definitions, examples, and scope notes, on several terms:
 
   - `gist:Building`: Issue [#482](https://github.com/semanticarts/gist/issues/482).
+  - `gist:uniqueText`: Issue[#577](https://github.com/semanticarts/gist/issues/577)
   
-Import URL: <https://ontologies.semanticarts.com/o/gistCore11.1.0>.
+Import URL: <https://ontologies.semanticarts.com/o/gistCore11.1.0>
 
 Release 11.0.0
 -----

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -8,10 +8,10 @@ Release 11.1.0
 
 ### Patch Updates
 
-- Improved the clarity and accuracy of annotations, including definitions, examples, and scope notes, on several terms:
+- Improved the clarity and accuracy of annotations on serveral terms, including definitions, examples, and scope notes:
 
   - `gist:Building`: Issue [#482](https://github.com/semanticarts/gist/issues/482).
-  - `gist:uniqueText`: Issue[#577](https://github.com/semanticarts/gist/issues/577)
+  - `gist:uniqueText`: Issue[#577](https://github.com/semanticarts/gist/issues/577).
   
 Import URL: <https://ontologies.semanticarts.com/o/gistCore11.1.0>
 

--- a/gistCore.ttl
+++ b/gistCore.ttl
@@ -3984,8 +3984,10 @@ gist:uniqueText
 		owl:FunctionalProperty
 		;
 	rdfs:range xsd:string ;
-	skos:definition "This is used for the actual value of a key or ID where you don't want the possibility of having more than one."^^xsd:string ;
+	skos:definition "The unique string value of some content object; i.e., there is no possibility of having more than one value."^^xsd:string ;
+	skos:example "The unique string for a vehicle identification number."^^xsd:string ;
 	skos:prefLabel "unique text"^^xsd:string ;
+	gist:domainIncludes gist:ID ;
 	.
 
 gist:unitSymbol


### PR DESCRIPTION
Note that the release notes in this PR include the release note from PR 674, because the updated annotations are included in a single release note.