### PR TITLE
Make `gist:isConnectedTo` symmetric. Fixes #699.

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -7,6 +7,7 @@ Release 11.1.0
 ### Minor Updates
 
 - Added new property `hasFirstMember`. Issue [#549](https://github.com/semanticarts/gist/issues/549).
+- Made `gist:isConnectedTo` symmetric. Issue [#699](https://github.com/semanticarts/gist/issues/699).
 
 ### Patch Updates
 

--- a/gistCore.ttl
+++ b/gistCore.ttl
@@ -3535,7 +3535,10 @@ gist:isCharacterizedAs
 	.
 
 gist:isConnectedTo
-	a owl:ObjectProperty ;
+	a
+		owl:ObjectProperty ,
+		owl:SymmetricProperty
+		;
 	skos:definition "A non-owning, non-causal, non-subordinate (i.e., peer-to-peer) relationship."^^xsd:string ;
 	skos:prefLabel "is connected to"^^xsd:string ;
 	.

--- a/ontologyShapes.ttl
+++ b/ontologyShapes.ttl
@@ -55,6 +55,7 @@ gshapes:InstanceShape
 					owl:DatatypeProperty
 					owl:TransitiveProperty
 					owl:FunctionalProperty
+					owl:SymmetricProperty
 					owl:ObjectProperty
 					owl:Restriction
 					owl:NamedIndividual


### PR DESCRIPTION
While adding the triple to indicate that `isConnectedTo` is symmetric, I received a SHACL validation error that `owl:SymmetricProperty` is an undefined class. To address this, I have added `owl:SymmetricProperty` to the list of classes in InstanceShape within ontologyShapes.ttl.