### PR TITLE
Removed and deprecated obsolete instances. Fixes #692.

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -6,6 +6,7 @@ Release 11.1.0
 
 ### Minor Updates
 
+- removed and deprecated `gist:_greenwichTimeZone`, `gist:_one_day`, `gist:_one_millisecond`, and `gist:_one_minute`. Issue [#692](https://github.com/semanticarts/gist/issues/692).
 - Added new property `hasFirstMember`. Issue [#549](https://github.com/semanticarts/gist/issues/549).
 - Made `gist:isConnectedTo` symmetric. Issue [#699](https://github.com/semanticarts/gist/issues/699).
 - Replaced `rdfs:range` on `gist:conformsTo` with `gist:rangeIncludes`. Issue [#700](https://github.com/semanticarts/gist/issues/700).

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -14,8 +14,8 @@ Release 11.1.0
 
 ### Patch Updates
 
-- Changed `startDateTime` to `actualStartDateTime` in formal definition of `gist:ContemporaryEvent`. Issue [#696](https://github.com/semanticarts/gist/issues/696).
-- Improved the clarity and accuracy of annotations on serveral terms, including definitions, examples, and scope notes:
+- Changed superproperty `startDateTime` to `actualStartDateTime` in formal definition of `gist:ContemporaryEvent`. Issue [#696](https://github.com/semanticarts/gist/issues/696).
+- Improved the clarity and accuracy of annotations on several terms, including definitions, examples, and scope notes:
 
   - `gist:Building`: Issue [#482](https://github.com/semanticarts/gist/issues/482).
   - `gist:PhysicalSubstance` and `gist:PhysicalIdentifiableItem`: Issue [#644](https://github.com/semanticarts/gist/issues/644).

--- a/gistCore.ttl
+++ b/gistCore.ttl
@@ -2640,16 +2640,6 @@ gist:_each
 	gist:hasBaseUnit gist:_each ;
 	.
 
-gist:_greenwichTimeZone
-	a
-		owl:NamedIndividual ,
-		owl:Thing ,
-		gist:TimeZoneStandard
-		;
-	skos:definition "The time zone containing the Royal Observatory in Greenwich, England, which is located on the prime meridian."^^xsd:string ;
-	skos:prefLabel "Greenwich Time Zone"^^xsd:string ;
-	.
-
 gist:_kelvin
 	a
 		owl:NamedIndividual ,
@@ -2725,45 +2715,6 @@ gist:_mole
 	gist:conversionFactor "1.0"^^xsd:double ;
 	gist:hasBaseUnit gist:_mole ;
 	gist:unitSymbol "mol"^^xsd:string ;
-	.
-
-gist:_one_day
-	a
-		owl:NamedIndividual ,
-		owl:Thing ,
-		gist:Duration
-		;
-	skos:definition "A duration equal to 24 hours."^^xsd:string ;
-	skos:prefLabel "one day"^^xsd:string ;
-	skos:scopeNote "This is a gist:Magnutude, not a unit of measure, it means essentially the same thing as the unit, day."^^xsd:string ;
-	gist:hasUnitOfMeasure gist:_day ;
-	gist:numericValue "1.0"^^xsd:double ;
-	.
-
-gist:_one_millisecond
-	a
-		owl:NamedIndividual ,
-		owl:Thing ,
-		gist:Duration
-		;
-	skos:definition "A duration equal to one millisecond."^^xsd:string ;
-	skos:prefLabel "one millisecond"^^xsd:string ;
-	skos:scopeNote "This is a gist:Magnutude, not a unit of measure, it means essentially the same thing as the unit, millisecond."^^xsd:string ;
-	gist:hasUnitOfMeasure gist:_millisecond ;
-	gist:numericValue "1.0"^^xsd:double ;
-	.
-
-gist:_one_minute
-	a
-		owl:NamedIndividual ,
-		owl:Thing ,
-		gist:Duration
-		;
-	skos:definition "A duration equal to one minute."^^xsd:string ;
-	skos:prefLabel "one minute"^^xsd:string ;
-	skos:scopeNote "This is a gist:Magnutude, not a unit of measure, it means essentially the same thing as the unit, minute."^^xsd:string ;
-	gist:hasUnitOfMeasure gist:_minute ;
-	gist:numericValue "1.0"^^xsd:double ;
 	.
 
 gist:_second

--- a/gistDeprecated.ttl
+++ b/gistDeprecated.ttl
@@ -1,0 +1,68 @@
+# imports: https://ontologies.semanticarts.com/o/gistCoreX.x.x
+
+@prefix gist: <https://ontologies.semanticarts.com/gist/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<https://ontologies.semanticarts.com/o/gistDeprecated>
+	a owl:Ontology ;
+	owl:imports <https://ontologies.semanticarts.com/o/gistCoreX.x.x> ;
+	owl:versionIRI <https://ontologies.semanticarts.com/o/gistDeprecatedX.x.x> ;
+	skos:definition "Concepts that have been deprecated since the last major release (in this case, 10.0.0)."^^xsd:string ;
+	skos:prefLabel "gistDeprecated"^^xsd:string ;
+	skos:scopeNote "This file will be removed on the next major release."^^xsd:string ;
+	gist:license "https://creativecommons.org/licenses/by-sa/3.0/"^^xsd:string ;
+	.
+
+gist:_greenwichTimeZone
+	a
+		owl:NamedIndividual ,
+		owl:Thing ,
+		gist:TimeZoneStandard
+		;
+	skos:definition "The time zone containing the Royal Observatory in Greenwich, England, which is located on the prime meridian."^^xsd:string ;
+	skos:prefLabel "Greenwich Time Zone"^^xsd:string ;
+	.
+
+gist:_one_day
+	a
+		owl:NamedIndividual ,
+		owl:Thing ,
+		gist:Duration
+		;
+	skos:definition "A duration equal to 24 hours."^^xsd:string ;
+	skos:prefLabel "one day"^^xsd:string ;
+	skos:scopeNote "This is a gist:Magnutude, not a unit of measure, it means essentially the same thing as the unit, day."^^xsd:string ;
+	gist:hasUnitOfMeasure gist:_day ;
+	gist:numericValue "1.0"^^xsd:double ;
+	.
+
+gist:_one_millisecond
+	a
+		owl:NamedIndividual ,
+		owl:Thing ,
+		gist:Duration
+		;
+	skos:definition "A duration equal to one millisecond."^^xsd:string ;
+	skos:prefLabel "one millisecond"^^xsd:string ;
+	skos:scopeNote "This is a gist:Magnutude, not a unit of measure, it means essentially the same thing as the unit, millisecond."^^xsd:string ;
+	gist:hasUnitOfMeasure gist:_millisecond ;
+	gist:numericValue "1.0"^^xsd:double ;
+	.
+
+gist:_one_minute
+	a
+		owl:NamedIndividual ,
+		owl:Thing ,
+		gist:Duration
+		;
+	skos:definition "A duration equal to one minute."^^xsd:string ;
+	skos:prefLabel "one minute"^^xsd:string ;
+	skos:scopeNote "This is a gist:Magnutude, not a unit of measure, it means essentially the same thing as the unit, minute."^^xsd:string ;
+	gist:hasUnitOfMeasure gist:_minute ;
+	gist:numericValue "1.0"^^xsd:double ;
+	.
+

--- a/gistDeprecated.ttl
+++ b/gistDeprecated.ttl
@@ -11,8 +11,8 @@
 	a owl:Ontology ;
 	owl:imports <https://ontologies.semanticarts.com/o/gistCoreX.x.x> ;
 	owl:versionIRI <https://ontologies.semanticarts.com/o/gistDeprecatedX.x.x> ;
-	skos:definition "Concepts that have been deprecated since the last major release (in this case, 10.0.0)."^^xsd:string ;
-	skos:prefLabel "gistDeprecated"^^xsd:string ;
+	skos:definition "Concepts that have been deprecated since the last major release."^^xsd:string ;
+	skos:prefLabel "gist deprecated"^^xsd:string ;
 	skos:scopeNote "This file will be removed on the next major release."^^xsd:string ;
 	gist:license "https://creativecommons.org/licenses/by-sa/3.0/"^^xsd:string ;
 	.
@@ -23,6 +23,7 @@ gist:_greenwichTimeZone
 		owl:Thing ,
 		gist:TimeZoneStandard
 		;
+	owl:deprecated "true"^^xsd:boolean ;
 	skos:definition "The time zone containing the Royal Observatory in Greenwich, England, which is located on the prime meridian."^^xsd:string ;
 	skos:prefLabel "Greenwich Time Zone"^^xsd:string ;
 	.
@@ -33,6 +34,7 @@ gist:_one_day
 		owl:Thing ,
 		gist:Duration
 		;
+	owl:deprecated "true"^^xsd:boolean ;
 	skos:definition "A duration equal to 24 hours."^^xsd:string ;
 	skos:prefLabel "one day"^^xsd:string ;
 	skos:scopeNote "This is a gist:Magnutude, not a unit of measure, it means essentially the same thing as the unit, day."^^xsd:string ;
@@ -46,6 +48,7 @@ gist:_one_millisecond
 		owl:Thing ,
 		gist:Duration
 		;
+	owl:deprecated "true"^^xsd:boolean ;
 	skos:definition "A duration equal to one millisecond."^^xsd:string ;
 	skos:prefLabel "one millisecond"^^xsd:string ;
 	skos:scopeNote "This is a gist:Magnutude, not a unit of measure, it means essentially the same thing as the unit, millisecond."^^xsd:string ;
@@ -59,6 +62,7 @@ gist:_one_minute
 		owl:Thing ,
 		gist:Duration
 		;
+	owl:deprecated "true"^^xsd:boolean ;
 	skos:definition "A duration equal to one minute."^^xsd:string ;
 	skos:prefLabel "one minute"^^xsd:string ;
 	skos:scopeNote "This is a gist:Magnutude, not a unit of measure, it means essentially the same thing as the unit, minute."^^xsd:string ;


### PR DESCRIPTION
Issue [#692](https://github.com/semanticarts/gist/issues/692).

Removed and deprecated `gist:_greenwichTimeZone`, `gist:_one_day`, `gist:_one_millisecond`, and `gist:_one_minute`. 