### PR TITLE
BugFix: isRecordedAt is now a subproperty of gist:atDateTime. Fixes #726.

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -6,6 +6,7 @@ Release 11.1.0
 
 ### Minor Updates
 
+- BugFix: `isRecordedAt` is now a subproperty of `gist:atDateTime` instead of `gist:actualEndDateTime`. Issue [#726](https://github.com/semanticarts/gist/issues/726).
 - Added new property `hasFirstMember`. Issue [#549](https://github.com/semanticarts/gist/issues/549).
 - Made `gist:isConnectedTo` symmetric. Issue [#699](https://github.com/semanticarts/gist/issues/699).
 - Replaced `rdfs:range` on `gist:conformsTo` with `gist:rangeIncludes`. Issue [#700](https://github.com/semanticarts/gist/issues/700).

--- a/gistCore.ttl
+++ b/gistCore.ttl
@@ -3653,7 +3653,7 @@ gist:isRecognizedDirectlyBy
 
 gist:isRecordedAt
 	a owl:DatatypeProperty ;
-	rdfs:subPropertyOf gist:actualEndDateTime ;
+	rdfs:subPropertyOf gist:atDateTime ;
 	skos:definition "Date that something was posted, not necessarily the date it occurred. Must be after the date of occurrence, but could be before or after the planned date. (Unusual, but I could record today that I expected to be paid last week.)"^^xsd:string ;
 	skos:prefLabel "is recorded at"^^xsd:string ;
 	skos:scopeNote "Precision may vary according to context."^^xsd:string ;


### PR DESCRIPTION
Issue #726 