### PR TITLE
Changes to precedes and follows predicates. Fixes #300.

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -10,10 +10,10 @@ Release 11.1.0
 - Bug fix: `isRecordedAt` is now a subproperty of `gist:atDateTime` instead of `gist:actualEndDateTime`. Issue [#726](https://github.com/semanticarts/gist/issues/726).
 - Added new property `hasFirstMember`. Issue [#549](https://github.com/semanticarts/gist/issues/549).
 - Updates related to `gist:isConnectedTo`:
--
+
   - Made the property symmetric. Issue [#699](https://github.com/semanticarts/gist/issues/699).
   - Replaced it in the restriction on `TemporalRelation` with `hasParticipant`. Issue [#706](https://github.com/semanticarts/gist/issues/706).
-  -
+  
 - Replaced `rdfs:range` on `gist:conformsTo` with `gist:rangeIncludes`. Issue [#700](https://github.com/semanticarts/gist/issues/700).
 - Reformatted gist for Protege + serializer compatibility. Issue [#646](https://github.com/semanticarts/gist/issues/646).
 - Added the inadvertently omitted predicate `gist:follows`. Issue [#300](https://github.com/semanticarts/gist/issues/300).

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -16,6 +16,7 @@ Release 11.1.0
   -
 - Replaced `rdfs:range` on `gist:conformsTo` with `gist:rangeIncludes`. Issue [#700](https://github.com/semanticarts/gist/issues/700).
 - Reformatted gist for Protege + serializer compatibility. Issue [#646](https://github.com/semanticarts/gist/issues/646).
+- Added the inadvertently omitted predicate `gist:follows`. Issue [#300](https://github.com/semanticarts/gist/issues/300).
 
 ### Patch Updates
 
@@ -25,6 +26,7 @@ Release 11.1.0
   - `gist:Building`: Issue [#482](https://github.com/semanticarts/gist/issues/482).
   - `gist:PhysicalSubstance` and `gist:PhysicalIdentifiableItem`: Issue [#644](https://github.com/semanticarts/gist/issues/644).
   - `gist:uniqueText`: Issue[#577](https://github.com/semanticarts/gist/issues/577).
+  - `gist:precedes`, `gist:precedesDirectly`, and `gist:followsDirectly`. Issue [#300](https://github.com/semanticarts/gist/issues/300).
 
 Import URL: <https://ontologies.semanticarts.com/o/gistCore11.1.0>.
 

--- a/gistCore.ttl
+++ b/gistCore.ttl
@@ -3033,8 +3033,25 @@ gist:endDateTime
 		;
 	.
 
+gist:follows
+	a
+		owl:ObjectProperty ,
+		owl:AsymmetricProperty ,
+		owl:IrreflexiveProperty ,
+		owl:TransitiveProperty
+		;
+	skos:definition "A generic ordering relation indicating that the subject comes after the object. The greater-than symbol is often used for this relation."^^xsd:string ;
+	skos:prefLabel "follows"^^xsd:string ;
+	skos:scopeNote "This is the transitive version of gist:followsDirectly."^^xsd:string ;
+	.
+
 gist:followsDirectly
-	a owl:ObjectProperty ;
+	a
+		owl:ObjectProperty ,
+		owl:AsymmetricProperty ,
+		owl:IrreflexiveProperty
+		;
+	rdfs:subPropertyOf gist:follows ;
 	owl:inverseOf gist:precedesDirectly ;
 	skos:definition "A generic ordering relation indicating that the subject comes immediately after the object."^^xsd:string ;
 	skos:prefLabel "follows directly"^^xsd:string ;

--- a/gistCore.ttl
+++ b/gistCore.ttl
@@ -3038,7 +3038,10 @@ gist:followsDirectly
 	owl:inverseOf gist:precedesDirectly ;
 	skos:definition "A generic ordering relation indicating that the subject comes immediately after the object."^^xsd:string ;
 	skos:prefLabel "follows directly"^^xsd:string ;
-	skos:scopeNote "It is safest to use this property only when the directness has a semantic correspondence with the world. Only break a direct link by inserting an intermediate item when that change corresponds to a change in the world."^^xsd:string ;
+	skos:scopeNote
+		"If two items in an ordered collection share the same position, they both directly follow the preceding element."^^xsd:string ,
+		"It is safest to use this property only when the directness has a semantic correspondence with the world. Only break a direct link by inserting an intermediate item when that change corresponds to a change in the world."^^xsd:string
+		;
 	.
 
 gist:goesToAgent
@@ -3853,18 +3856,28 @@ gist:plannedStartYear
 gist:precedes
 	a
 		owl:ObjectProperty ,
+		owl:AsymmetricProperty ,
+		owl:IrreflexiveProperty ,
 		owl:TransitiveProperty
 		;
-	skos:definition "A generic ordering relation indicating that the subject has the same order as or comes before the object. The 'greater than or equal to' symbol is often used for this relation."^^xsd:string ;
+	skos:definition "A generic ordering relation indicating that the subject comes before the object. The less-than symbol is often used for this relation."^^xsd:string ;
 	skos:prefLabel "precedes"^^xsd:string ;
+	skos:scopeNote "This is the transitive version of gist:precedesDirectly."^^xsd:string ;
 	.
 
 gist:precedesDirectly
-	a owl:ObjectProperty ;
+	a
+		owl:ObjectProperty ,
+		owl:AsymmetricProperty ,
+		owl:IrreflexiveProperty
+		;
 	rdfs:subPropertyOf gist:precedes ;
 	skos:definition "A generic ordering relation indicating that the subject comes immediately before the object."^^xsd:string ;
 	skos:prefLabel "precedes directly"^^xsd:string ;
-	skos:scopeNote "It is safest to use this property only when the directness has a semantic correspondence with the world. Only break a direct link by inserting an intermediate item when that change corresponds to a change in the world."^^xsd:string ;
+	skos:scopeNote
+		"If two items in an ordered collection share the same position, they both directly precede the following element."^^xsd:string ,
+		"It is safest to use this property only when the directness has a semantic correspondence with the world. Only break a direct link by inserting an intermediate item when that change corresponds to a change in the world."^^xsd:string
+		;
 	.
 
 gist:prevents

--- a/gistCore.ttl
+++ b/gistCore.ttl
@@ -3036,31 +3036,27 @@ gist:endDateTime
 gist:follows
 	a
 		owl:ObjectProperty ,
-		owl:AsymmetricProperty ,
-		owl:IrreflexiveProperty ,
 		owl:TransitiveProperty
 		;
 	skos:definition "A generic ordering relation indicating that the subject comes after the object."^^xsd:string ;
 	skos:prefLabel "follows"^^xsd:string ;
 	skos:scopeNote
 		"The greater-than symbol is often used to represent this relation."^^xsd:string ,
-		"This is the transitive version of gist:followsDirectly."^^xsd:string
+		"This is the transitive version of gist:followsDirectly."^^xsd:string ,
+		"Typically this predicate would be used asymmetricallly and irreflexively, but the ontology does not formalize this."^^xsd:string
 		;
 	.
 
 gist:followsDirectly
-	a
-		owl:ObjectProperty ,
-		owl:AsymmetricProperty ,
-		owl:IrreflexiveProperty
-		;
+	a owl:ObjectProperty ;
 	rdfs:subPropertyOf gist:follows ;
 	owl:inverseOf gist:precedesDirectly ;
 	skos:definition "A generic ordering relation indicating that the subject comes immediately after the object."^^xsd:string ;
 	skos:prefLabel "follows directly"^^xsd:string ;
 	skos:scopeNote
 		"If two items in an ordered collection share the same position, they both directly follow the preceding element."^^xsd:string ,
-		"It is safest to use this property only when the directness has a semantic correspondence with the world. Only break a direct link by inserting an intermediate item when that change corresponds to a change in the world."^^xsd:string
+		"It is safest to use this property only when the directness has a semantic correspondence with the world. Only break a direct link by inserting an intermediate item when that change corresponds to a change in the world."^^xsd:string ,
+		"Typically this predicate would be used asymmetricallly and irreflexively, but the ontology does not formalize this."^^xsd:string
 		;
 	.
 
@@ -3876,30 +3872,26 @@ gist:plannedStartYear
 gist:precedes
 	a
 		owl:ObjectProperty ,
-		owl:AsymmetricProperty ,
-		owl:IrreflexiveProperty ,
 		owl:TransitiveProperty
 		;
 	skos:definition "A generic ordering relation indicating that the subject comes before the object."^^xsd:string ;
 	skos:prefLabel "precedes"^^xsd:string ;
 	skos:scopeNote
 		"The less-than symbol is often used to represent this relation."^^xsd:string ,
-		"This is the transitive version of gist:precedesDirectly."^^xsd:string
+		"This is the transitive version of gist:precedesDirectly."^^xsd:string ,
+		"Typically this predicate would be used asymmetricallly and irreflexively, but the ontology does not formalize this."^^xsd:string
 		;
 	.
 
 gist:precedesDirectly
-	a
-		owl:ObjectProperty ,
-		owl:AsymmetricProperty ,
-		owl:IrreflexiveProperty
-		;
+	a owl:ObjectProperty ;
 	rdfs:subPropertyOf gist:precedes ;
 	skos:definition "A generic ordering relation indicating that the subject comes immediately before the object."^^xsd:string ;
 	skos:prefLabel "precedes directly"^^xsd:string ;
 	skos:scopeNote
 		"If two items in an ordered collection share the same position, they both directly precede the following element."^^xsd:string ,
-		"It is safest to use this property only when the directness has a semantic correspondence with the world. Only break a direct link by inserting an intermediate item when that change corresponds to a change in the world."^^xsd:string
+		"It is safest to use this property only when the directness has a semantic correspondence with the world. Only break a direct link by inserting an intermediate item when that change corresponds to a change in the world."^^xsd:string ,
+		"Typically this predicate would be used asymmetricallly and irreflexively, but the ontology does not formalize this."^^xsd:string
 		;
 	.
 

--- a/gistCore.ttl
+++ b/gistCore.ttl
@@ -3040,9 +3040,12 @@ gist:follows
 		owl:IrreflexiveProperty ,
 		owl:TransitiveProperty
 		;
-	skos:definition "A generic ordering relation indicating that the subject comes after the object. The greater-than symbol is often used for this relation."^^xsd:string ;
+	skos:definition "A generic ordering relation indicating that the subject comes after the object."^^xsd:string ;
 	skos:prefLabel "follows"^^xsd:string ;
-	skos:scopeNote "This is the transitive version of gist:followsDirectly."^^xsd:string ;
+	skos:scopeNote
+		"The greater-than symbol is often used to represent this relation."^^xsd:string ,
+		"This is the transitive version of gist:followsDirectly."^^xsd:string
+		;
 	.
 
 gist:followsDirectly
@@ -3877,9 +3880,12 @@ gist:precedes
 		owl:IrreflexiveProperty ,
 		owl:TransitiveProperty
 		;
-	skos:definition "A generic ordering relation indicating that the subject comes before the object. The less-than symbol is often used for this relation."^^xsd:string ;
+	skos:definition "A generic ordering relation indicating that the subject comes before the object."^^xsd:string ;
 	skos:prefLabel "precedes"^^xsd:string ;
-	skos:scopeNote "This is the transitive version of gist:precedesDirectly."^^xsd:string ;
+	skos:scopeNote
+		"The less-than symbol is often used to represent this relation."^^xsd:string ,
+		"This is the transitive version of gist:precedesDirectly."^^xsd:string
+		;
 	.
 
 gist:precedesDirectly

--- a/gistCore.ttl
+++ b/gistCore.ttl
@@ -3038,6 +3038,7 @@ gist:follows
 		owl:ObjectProperty ,
 		owl:TransitiveProperty
 		;
+	owl:inverseOf gist:precedes ;
 	skos:definition "A generic ordering relation indicating that the subject comes after the object."^^xsd:string ;
 	skos:prefLabel "follows"^^xsd:string ;
 	skos:scopeNote

--- a/ontologyShapes.ttl
+++ b/ontologyShapes.ttl
@@ -53,9 +53,12 @@ gshapes:InstanceShape
 					owl:AllDifferent
 					owl:InverseFunctionalProperty
 					owl:DatatypeProperty
+					owl:ReflexiveProperty
+					owl:IrreflexiveProperty
 					owl:TransitiveProperty
 					owl:FunctionalProperty
 					owl:SymmetricProperty
+					owl:AsymmetricProperty
 					owl:ObjectProperty
 					owl:Restriction
 					owl:NamedIndividual


### PR DESCRIPTION
This PR includes:

1. Changed the definition of `gist:precedes` to exclude same order. 
2. Added OWL type assertions to `gist:precedes`, `gist:precedesDirectly`, and `gist:followsDirectly` to formally express this (asymmetric and irreflexive).
3. Updated ontologyShapes.ttl to accept these OWL types.
4. Added scope notes to `gist:precedesDirectly` and `gist:followsDirectly` about how to express same order.
5. Added predicate `gist:follows`, since during this work it was found to be missing.
6. A few miscellaneous modifications to gistDeprecated.ttl and the release notes.

Item 5 is technically beyond the scope of issue #300, but given that it's a bug fix it seemed acceptable to add it here.  Item 6 is also outside the scope but address small omissions I noted along the way.