### PR TITLE
Update list of documents in bundle.yaml

### DIFF
--- a/bundle.yaml
+++ b/bundle.yaml
@@ -185,11 +185,11 @@ actions:
     from: "\\(./(\\w+)\\.md\\)"
     to: "(./\\g<1>.html)"
   includes:
+    - "Contributing.md"
+    - "gistStyleGuide.md"
     - "ReleaseNotes.md"
     - "MajorVersionMigration.md"
     - "gistDocumentation.md"
-    - "README.md"
-    - "TimeRelatedChanges_v11.md"
 - action: "markdown"
   message: "Formatting release notes."
   source: "{output}/Documentation/ReleaseNotes.md"


### PR DESCRIPTION
Fixes #746 

Mainly the list of document files was outdated.

I noticed that you have to explicitly list all markdown files that you want converted to HTML. It would be better to not have to keep that list updated every release but I think that would require leaving them as .md files or making a change to onto-tool. Maybe this should be added to the release documentation as a step (if it hasn't been added previously).