### PR TITLE
Add shacl and skos imports; gitignore catalog files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *_webDownload/
 .DS_Store
 *.orig
+/catalog-v001.xml

--- a/gistCore.ttl
+++ b/gistCore.ttl
@@ -1,3 +1,6 @@
+# imports: http://www.w3.org/2004/02/skos/core#
+# imports: http://www.w3.org/ns/shacl#
+
 @prefix : <https://ontologies.semanticarts.com/o/gistCore#> .
 @prefix gist: <https://ontologies.semanticarts.com/gist/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
@@ -10,6 +13,10 @@
 
 <https://ontologies.semanticarts.com/o/gistCore>
 	a owl:Ontology ;
+	owl:imports
+		<http://www.w3.org/2004/02/skos/core#> ,
+		<http://www.w3.org/ns/shacl#>
+		;
 	owl:versionIRI <https://ontologies.semanticarts.com/o/gistCoreX.x.x> ;
 	skos:definition "gist is a minimalist upper ontology created by Semantic Arts."^^xsd:string ;
 	skos:prefLabel "gist"^^xsd:string ;


### PR DESCRIPTION
Add SKOS and SHACL imports so Protege does not create stub definitions in exports.