### PR TITLE
Add owl:Thing assertions to duration units. Fixes #775.

### DIFF
--- a/docs/release_notes/pr783.md
+++ b/docs/release_notes/pr783.md
@@ -1,0 +1,3 @@
+### Patch Updates
+
+- Added missing `owl:Thing` assertions to duration units to ensure `rdfs:isDefinedBy` assertions are generated in release package. Issue [#775](https://github.com/semanticarts/gist/issues/775).

--- a/gistCore.ttl
+++ b/gistCore.ttl
@@ -2615,6 +2615,7 @@ gist:_candela
 gist:_day
 	a
 		owl:NamedIndividual ,
+		owl:Thing ,
 		gist:DurationUnit
 		;
 	skos:definition "A duration unit that is 24 hours long."^^xsd:string ;
@@ -2678,6 +2679,7 @@ gist:_meter
 gist:_millisecond
 	a
 		owl:NamedIndividual ,
+		owl:Thing ,
 		gist:DurationUnit
 		;
 	skos:definition "A unit equal to a thousandth of a second."^^xsd:string ;
@@ -2690,6 +2692,7 @@ gist:_millisecond
 gist:_minute
 	a
 		owl:NamedIndividual ,
+		owl:Thing ,
 		gist:DurationUnit
 		;
 	skos:definition "A unit equal to 60 seconds."^^xsd:string ;


### PR DESCRIPTION
Fixes #775.