### PR TITLE
Feature/issue 782 simplify units. Fixes #782.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 *_webDownload/
 .DS_Store
 *.orig
+
+gistUnitsMagnitudes-PROTEGE.ttl

--- a/docs/release_notes/Issue-782.md
+++ b/docs/release_notes/Issue-782.md
@@ -1,9 +1,46 @@
 ### Major Updates
-- CoherentUnit
-  - Rename CoherentUnit to StandardUnit with altLabel as CoherentUnit
-  - Change formal definition to be a UnitOfMeasure with itself as a standerd unit and conversion of 1.
+- CoherentUnit / StandardUnit
+  - Renamed CoherentUnit to StandardUnit with altLabel as CoherentUnit
+  - Changed formal definition to be equivalent to a UnitOfMeasure that
+    - has conversion=1
+    - has itself as a standard unit
+    - has a scopeNote indicating that this captures the idea of dimensiona UnitOfMeasure with itself as a standerd unit and conversion of 1.
+  - Made hasStandardUnit functional
+- UnitOfMeasure
+  -  made equivalent to a Magnitude that
+    - has numericValue =1 (it's not called 'unit' for nothing)
+    - has itself at its unit of measure
+    - has conversion=1
+    - has a standard unit
+  - removed UnitOfMeasuree from disjoints where incorrect or redundant
 
+- Removed product and ratio units and magnitudes
+  - Removed: ProductUnit, CoherentProductUnit, ProductMagnitude
+  - Removed: RatioUnit, CoherentRatioUnit, RatioMagnitude
+  - Percentage was redefined because it had been a subclass of RatioMagnitude which was defined in terms of RationUnit. The old definitions are inserted as blank nodes to retain same formal meaning.
+
+- Aspect
+  - Make Aspect a not a subclass of Category.  Aspects such as like length, or inner diameter or cycle time do not exist for the purpose of categorizing things.
+  - Make Aspect a subclass of SchemaMetaData. An aspect is a representation of a property connecting two things. It has roughly the same meaning as an OWL property.
+
+- Renamed Extent to Distance for consistency with DistanceUnit
+- Renamed MolarQuantity to MoleQuantity and CountingUnit to CountUnit for consistency
+- Renamed InformationQuantity to DataSize for naming consistency
 
 ### Minor Updates
+- Moved an annotation about units from Magnitude to a better home: UnitOfMeasure
+- Fixed an erroneous definition of Magnitude and added examples
+- Added scopeNote for hasPrecision to say the precision of a Magnitude must have the same StandardUnit as the Magnitude.
+- Removed and deprecated SimpleUnitOfMeasure
+- Removed and deprecated hasBaseUnit. Use hasStandardUnit instead.
+- Removed redundant typing of BaseUnits, can be inferred from enumeration.
+- Added square meter and cubic meter as standard units for Area and Volume units respectively.
+- Made cubic_meter and square_meter explicit instances of just UnitOfMeasure instead of VolumeUnit and AreaUnit, respectively.
+- AreaUnit is now equivalent to UnitOfMeasure with standard unit of square meter, no longer requiring multipier/multiplicand
+- VolumeUnit is now equivalent to UnitOfMeasure with standard unit of cubic meter, no longer requiring multipier/multiplicand
+- Made non-standard units (e.g. minute) explicit instances of UnitOfMeasure rather than of the more specifit class, (e..g DurationUnit)
 
--  
+
+
+
+

--- a/docs/release_notes/Issue-782.md
+++ b/docs/release_notes/Issue-782.md
@@ -1,0 +1,7 @@
+### Major Updates
+- 
+
+
+### Minor Updates
+
+- xx Rename CoherentUnit to StandardUnit with altLabel as CoherentUnit

--- a/docs/release_notes/Issue-782.md
+++ b/docs/release_notes/Issue-782.md
@@ -1,7 +1,9 @@
 ### Major Updates
-- 
+- CoherentUnit
+  - Rename CoherentUnit to StandardUnit with altLabel as CoherentUnit
+  - Change formal definition to be a UnitOfMeasure with itself as a standerd unit and conversion of 1.
 
 
 ### Minor Updates
 
-- xx Rename CoherentUnit to StandardUnit with altLabel as CoherentUnit
+-  

--- a/gistCore.ttl
+++ b/gistCore.ttl
@@ -2518,7 +2518,7 @@ gist:_cubic_meter
 gist:_day
 	a
 		owl:NamedIndividual ,
-		gist:DurationUnit
+		gist:UnitOfMeasure
 		;
 	skos:definition "A duration unit that is 24 hours long."^^xsd:string ;
 	skos:prefLabel "day"^^xsd:string ;
@@ -2577,7 +2577,7 @@ gist:_meter
 gist:_millisecond
 	a
 		owl:NamedIndividual ,
-		gist:DurationUnit
+		gist:UnitOfMeasure
 		;
 	skos:definition "A unit equal to a thousandth of a second."^^xsd:string ;
 	skos:prefLabel "millisecond"^^xsd:string ;
@@ -2589,7 +2589,7 @@ gist:_millisecond
 gist:_minute
 	a
 		owl:NamedIndividual ,
-		gist:DurationUnit
+		gist:UnitOfMeasure
 		;
 	skos:definition "A unit equal to 60 seconds."^^xsd:string ;
 	skos:prefLabel "minute"^^xsd:string ;

--- a/gistCore.ttl
+++ b/gistCore.ttl
@@ -526,7 +526,7 @@ gist:CountingUnit
 			gist:UnitOfMeasure
 			[
 				a owl:Restriction ;
-				owl:onProperty gist:hasBaseUnit ;
+				owl:onProperty gist:hasStandardUnit ;
 				owl:hasValue gist:_each ;
 			]
 		) ;
@@ -597,7 +597,7 @@ gist:CurrencyUnit
 			gist:UnitOfMeasure
 			[
 				a owl:Restriction ;
-				owl:onProperty gist:hasBaseUnit ;
+				owl:onProperty gist:hasStandardUnit ;
 				owl:hasValue gist:_USDollar ;
 			]
 		) ;
@@ -623,7 +623,7 @@ gist:DataSizeUnit
 			gist:UnitOfMeasure
 			[
 				a owl:Restriction ;
-				owl:onProperty gist:hasBaseUnit ;
+				owl:onProperty gist:hasStandardUnit ;
 				owl:hasValue gist:_bit ;
 			]
 		) ;
@@ -656,7 +656,7 @@ gist:DistanceUnit
 			gist:UnitOfMeasure
 			[
 				a owl:Restriction ;
-				owl:onProperty gist:hasBaseUnit ;
+				owl:onProperty gist:hasStandardUnit ;
 				owl:hasValue gist:_meter ;
 			]
 		) ;
@@ -699,7 +699,7 @@ gist:DurationUnit
 			gist:UnitOfMeasure
 			[
 				a owl:Restriction ;
-				owl:onProperty gist:hasBaseUnit ;
+				owl:onProperty gist:hasStandardUnit ;
 				owl:hasValue gist:_second ;
 			]
 		) ;
@@ -739,7 +739,7 @@ gist:ElectricalCurrentUnit
 			gist:UnitOfMeasure
 			[
 				a owl:Restriction ;
-				owl:onProperty gist:hasBaseUnit ;
+				owl:onProperty gist:hasStandardUnit ;
 				owl:hasValue gist:_ampere ;
 			]
 		) ;
@@ -1245,7 +1245,7 @@ gist:LuminousIntensityUnit
 			gist:UnitOfMeasure
 			[
 				a owl:Restriction ;
-				owl:onProperty gist:hasBaseUnit ;
+				owl:onProperty gist:hasStandardUnit ;
 				owl:hasValue gist:_candela ;
 			]
 		) ;
@@ -1319,7 +1319,7 @@ gist:MassUnit
 			gist:UnitOfMeasure
 			[
 				a owl:Restriction ;
-				owl:onProperty gist:hasBaseUnit ;
+				owl:onProperty gist:hasStandardUnit ;
 				owl:hasValue gist:_kilogram ;
 			]
 		) ;
@@ -1411,7 +1411,7 @@ gist:MoleUnit
 			gist:UnitOfMeasure
 			[
 				a owl:Restriction ;
-				owl:onProperty gist:hasBaseUnit ;
+				owl:onProperty gist:hasStandardUnit ;
 				owl:hasValue gist:_mole ;
 			]
 		) ;
@@ -2208,7 +2208,7 @@ gist:TemperatureUnit
 			gist:UnitOfMeasure
 			[
 				a owl:Restriction ;
-				owl:onProperty gist:hasBaseUnit ;
+				owl:onProperty gist:hasStandardUnit ;
 				owl:hasValue gist:_kelvin ;
 			]
 			[
@@ -2438,7 +2438,7 @@ gist:_USDollar
 	skos:definition "The base unit for currency."^^xsd:string ;
 	skos:prefLabel "US Dollar"^^xsd:string ;
 	gist:conversionFactor "1.0"^^xsd:double ;
-	gist:hasBaseUnit gist:_USDollar ;
+	gist:hasStandardUnit gist:_USDollar ;
 	gist:unitSymbol "USD"^^xsd:string ;
 	.
 
@@ -2451,7 +2451,7 @@ gist:_ampere
 	skos:definition "The base unit for electrical current."^^xsd:string ;
 	skos:prefLabel "ampere"^^xsd:string ;
 	gist:conversionFactor "1.0"^^xsd:double ;
-	gist:hasBaseUnit gist:_ampere ;
+	gist:hasStandardUnit gist:_ampere ;
 	gist:unitSymbol "A"^^xsd:string ;
 	.
 
@@ -2465,7 +2465,7 @@ gist:_bit
 	skos:prefLabel "bit"^^xsd:string ;
 	skos:scopeNote "A bit (short for binary digit) is the smallest unit of data in a computer. A bit has a single binary value, either 0 or 1."^^xsd:string ;
 	gist:conversionFactor "1.0"^^xsd:double ;
-	gist:hasBaseUnit gist:_bit ;
+	gist:hasStandardUnit gist:_bit ;
 	.
 
 gist:_candela
@@ -2477,7 +2477,7 @@ gist:_candela
 	skos:definition "The base unit for luminous intensity."^^xsd:string ;
 	skos:prefLabel "candela"^^xsd:string ;
 	gist:conversionFactor "1.0"^^xsd:double ;
-	gist:hasBaseUnit gist:_candela ;
+	gist:hasStandardUnit gist:_candela ;
 	gist:unitSymbol "cd"^^xsd:string ;
 	.
 
@@ -2489,7 +2489,7 @@ gist:_day
 	skos:definition "A duration unit that is 24 hours long."^^xsd:string ;
 	skos:prefLabel "day"^^xsd:string ;
 	gist:conversionFactor "86400.0"^^xsd:double ;
-	gist:hasBaseUnit gist:_second ;
+	gist:hasStandardUnit gist:_second ;
 	.
 
 gist:_each
@@ -2501,7 +2501,7 @@ gist:_each
 	skos:definition "The base unit for count magnitudes."^^xsd:string ;
 	skos:prefLabel "each"^^xsd:string ;
 	gist:conversionFactor "1.0"^^xsd:double ;
-	gist:hasBaseUnit gist:_each ;
+	gist:hasStandardUnit gist:_each ;
 	.
 
 gist:_kelvin
@@ -2514,7 +2514,7 @@ gist:_kelvin
 	skos:prefLabel "Kelvin"^^xsd:string ;
 	gist:conversionFactor "1.0"^^xsd:double ;
 	gist:conversionOffset "0.0"^^xsd:double ;
-	gist:hasBaseUnit gist:_kelvin ;
+	gist:hasStandardUnit gist:_kelvin ;
 	gist:unitSymbol "K"^^xsd:string ;
 	.
 
@@ -2527,7 +2527,7 @@ gist:_kilogram
 	skos:definition "The base unit for measuring mass."^^xsd:string ;
 	skos:prefLabel "mass"^^xsd:string ;
 	gist:conversionFactor "1.0"^^xsd:double ;
-	gist:hasBaseUnit gist:_kilogram ;
+	gist:hasStandardUnit gist:_kilogram ;
 	gist:unitSymbol "kg"^^xsd:string ;
 	.
 
@@ -2540,7 +2540,7 @@ gist:_meter
 	skos:definition "The base unit for measuring distance."^^xsd:string ;
 	skos:prefLabel "distance"^^xsd:string ;
 	gist:conversionFactor "1.0"^^xsd:double ;
-	gist:hasBaseUnit gist:_meter ;
+	gist:hasStandardUnit gist:_meter ;
 	gist:unitSymbol "m"^^xsd:string ;
 	.
 
@@ -2552,7 +2552,7 @@ gist:_millisecond
 	skos:definition "A unit equal to a thousandth of a second."^^xsd:string ;
 	skos:prefLabel "millisecond"^^xsd:string ;
 	gist:conversionFactor "0.001"^^xsd:double ;
-	gist:hasBaseUnit gist:_second ;
+	gist:hasStandardUnit gist:_second ;
 	gist:unitSymbol "ms"^^xsd:string ;
 	.
 
@@ -2564,7 +2564,7 @@ gist:_minute
 	skos:definition "A unit equal to 60 seconds."^^xsd:string ;
 	skos:prefLabel "minute"^^xsd:string ;
 	gist:conversionFactor "60.0"^^xsd:double ;
-	gist:hasBaseUnit gist:_second ;
+	gist:hasStandardUnit gist:_second ;
 	gist:unitSymbol "min"^^xsd:string ;
 	.
 
@@ -2577,7 +2577,7 @@ gist:_mole
 	skos:definition "The base unit for measuring molar quantities."^^xsd:string ;
 	skos:prefLabel "mole"^^xsd:string ;
 	gist:conversionFactor "1.0"^^xsd:double ;
-	gist:hasBaseUnit gist:_mole ;
+	gist:hasStandardUnit gist:_mole ;
 	gist:unitSymbol "mol"^^xsd:string ;
 	.
 
@@ -2590,7 +2590,7 @@ gist:_second
 	skos:definition "The base unit for measuring durations."^^xsd:string ;
 	skos:prefLabel "second"^^xsd:string ;
 	gist:conversionFactor "1.0"^^xsd:double ;
-	gist:hasBaseUnit gist:_second ;
+	gist:hasStandardUnit gist:_second ;
 	gist:unitSymbol "s"^^xsd:string ;
 	.
 
@@ -2993,16 +2993,6 @@ gist:hasAltitude
 	rdfs:range gist:Extent ;
 	skos:definition "Distance above sea level"^^xsd:string ;
 	skos:prefLabel "has altitude"^^xsd:string ;
-	.
-
-gist:hasBaseUnit
-	a owl:ObjectProperty ;
-	rdfs:subPropertyOf gist:hasStandardUnit ;
-	rdfs:domain gist:UnitOfMeasure ;
-	rdfs:range gist:BaseUnit ;
-	skos:definition "Relates a UnitOfMeasure to its BaseUnit.  This indicates what kind of Unit something is."^^xsd:string ;
-	skos:example "Saying that a furlong hasBaseUnit  meter says it is a DistanceUnit."^^xsd:string ;
-	skos:prefLabel "has base unit"^^xsd:string ;
 	.
 
 gist:hasBiologicalParent

--- a/gistCore.ttl
+++ b/gistCore.ttl
@@ -96,29 +96,37 @@ gist:Area
 
 gist:AreaUnit
 	a owl:Class ;
-	owl:equivalentClass [
-		a owl:Class ;
-		owl:intersectionOf (
-			gist:UnitOfMeasure
-			[
-				a owl:Restriction ;
-				owl:onProperty gist:hasMultiplicand ;
-				owl:onClass gist:DistanceUnit ;
-				owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
-			]
-			[
-				a owl:Restriction ;
-				owl:onProperty gist:hasMultiplier ;
-				owl:onClass gist:DistanceUnit ;
-				owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
-			]
-			[
-				a owl:Restriction ;
-				owl:onProperty gist:hasStandardUnit ;
-				owl:hasValue gist:_square_meter ;
-			]
-		) ;
-	] ;
+	owl:equivalentClass
+		[
+			a owl:Class ;
+			owl:intersectionOf (
+				gist:UnitOfMeasure
+				[
+					a owl:Restriction ;
+					owl:onProperty gist:hasStandardUnit ;
+					owl:hasValue gist:_square_meter ;
+				]
+			) ;
+		] ,
+		[
+			a owl:Class ;
+			owl:intersectionOf (
+				gist:UnitOfMeasure
+				[
+					a owl:Restriction ;
+					owl:onProperty gist:hasMultiplicand ;
+					owl:onClass gist:DistanceUnit ;
+					owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+				]
+				[
+					a owl:Restriction ;
+					owl:onProperty gist:hasMultiplier ;
+					owl:onClass gist:DistanceUnit ;
+					owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+				]
+			) ;
+		]
+		;
 	skos:definition "A unit of two-dimensional area, such as square inches or hectares."^^xsd:string ;
 	skos:prefLabel "Area Unit"^^xsd:string ;
 	.
@@ -2406,29 +2414,37 @@ gist:Volume
 
 gist:VolumeUnit
 	a owl:Class ;
-	owl:equivalentClass [
-		a owl:Class ;
-		owl:intersectionOf (
-			gist:UnitOfMeasure
-			[
-				a owl:Restriction ;
-				owl:onProperty gist:hasMultiplicand ;
-				owl:onClass gist:AreaUnit ;
-				owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
-			]
-			[
-				a owl:Restriction ;
-				owl:onProperty gist:hasMultiplier ;
-				owl:onClass gist:DistanceUnit ;
-				owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
-			]
-			[
-				a owl:Restriction ;
-				owl:onProperty gist:hasStandardUnit ;
-				owl:hasValue gist:_cubic_meter ;
-			]
-		) ;
-	] ;
+	owl:equivalentClass
+		[
+			a owl:Class ;
+			owl:intersectionOf (
+				gist:UnitOfMeasure
+				[
+					a owl:Restriction ;
+					owl:onProperty gist:hasStandardUnit ;
+					owl:hasValue gist:_cubic_meter ;
+				]
+			) ;
+		] ,
+		[
+			a owl:Class ;
+			owl:intersectionOf (
+				gist:UnitOfMeasure
+				[
+					a owl:Restriction ;
+					owl:onProperty gist:hasMultiplicand ;
+					owl:onClass gist:AreaUnit ;
+					owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+				]
+				[
+					a owl:Restriction ;
+					owl:onProperty gist:hasMultiplier ;
+					owl:onClass gist:DistanceUnit ;
+					owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+				]
+			) ;
+		]
+		;
 	skos:definition "Units of three-dimensional space, expressed here as an area times a distance."^^xsd:string ;
 	skos:prefLabel "Volume Unit"^^xsd:string ;
 	.
@@ -2490,7 +2506,7 @@ gist:_candela
 gist:_cubic_meter
 	a
 		owl:Thing ,
-		gist:VolumeUnit
+		gist:UnitOfMeasure
 		;
 	gist:conversionFactor "1.0"^^xsd:double ;
 	gist:hasMultiplicand gist:_square_meter ;
@@ -2609,7 +2625,7 @@ gist:_second
 gist:_square_meter
 	a
 		owl:Thing ,
-		gist:AreaUnit
+		gist:UnitOfMeasure
 		;
 	gist:conversionFactor "1.0"^^xsd:double ;
 	gist:hasMultiplicand gist:_meter ;

--- a/gistCore.ttl
+++ b/gistCore.ttl
@@ -813,23 +813,6 @@ gist:Event
 	skos:prefLabel "Event"^^xsd:string ;
 	.
 
-gist:Extent
-	a owl:Class ;
-	owl:equivalentClass [
-		a owl:Class ;
-		owl:intersectionOf (
-			gist:Magnitude
-			[
-				a owl:Restriction ;
-				owl:onProperty gist:hasUnitOfMeasure ;
-				owl:someValuesFrom gist:DistanceUnit ;
-			]
-		) ;
-	] ;
-	skos:definition "A measure of distance, which could be distances over the Earth, and could also be height, width, length, depth, girth, etc."^^xsd:string ;
-	skos:prefLabel "Extent"^^xsd:string ;
-	.
-
 gist:FormattedContent
 	a owl:Class ;
 	owl:equivalentClass [
@@ -880,7 +863,7 @@ gist:GeoPoint
 			[
 				a owl:Restriction ;
 				owl:onProperty gist:hasAltitude ;
-				owl:someValuesFrom gist:Extent ;
+				owl:someValuesFrom gist:Distance ;
 			]
 			[
 				a owl:Restriction ;
@@ -2990,7 +2973,7 @@ gist:hasAddress
 gist:hasAltitude
 	a owl:ObjectProperty ;
 	rdfs:domain gist:GeoPoint ;
-	rdfs:range gist:Extent ;
+	rdfs:range gist:Distance ;
 	skos:definition "Distance above sea level"^^xsd:string ;
 	skos:prefLabel "has altitude"^^xsd:string ;
 	.

--- a/gistCore.ttl
+++ b/gistCore.ttl
@@ -619,6 +619,23 @@ gist:CurrencyUnit
 	skos:prefLabel "Currency Unit"^^xsd:string ;
 	.
 
+gist:DataSize
+	a owl:Class ;
+	owl:equivalentClass [
+		a owl:Class ;
+		owl:intersectionOf (
+			gist:Magnitude
+			[
+				a owl:Restriction ;
+				owl:onProperty gist:hasUnitOfMeasure ;
+				owl:someValuesFrom gist:DataSizeUnit ;
+			]
+		) ;
+	] ;
+	skos:definition "An amount of data, such as 6 petabytes, or 640KB."^^xsd:string ;
+	skos:prefLabel "Data Size"^^xsd:string ;
+	.
+
 gist:DataSizeUnit
 	a owl:Class ;
 	owl:disjointWith
@@ -1098,23 +1115,6 @@ gist:ID
 	skos:example "SSN for a person; serial number for a product; employee ID."^^xsd:string ;
 	skos:prefLabel "ID"^^xsd:string ;
 	skos:scopeNote "This is used in conjunction with gist:isIdentifiedBy"^^xsd:string ;
-	.
-
-gist:InformationQuantity
-	a owl:Class ;
-	owl:equivalentClass [
-		a owl:Class ;
-		owl:intersectionOf (
-			gist:Magnitude
-			[
-				a owl:Restriction ;
-				owl:onProperty gist:hasUnitOfMeasure ;
-				owl:someValuesFrom gist:DataSizeUnit ;
-			]
-		) ;
-	] ;
-	skos:definition "An amount of data, such as 6 petabytes, or 640KB."^^xsd:string ;
-	skos:prefLabel "Information Quantity"^^xsd:string ;
 	.
 
 gist:IntellectualProperty
@@ -2484,7 +2484,7 @@ gist:_bit
 		owl:NamedIndividual ,
 		owl:Thing
 		;
-	skos:definition "The base unit for measuring digital information."^^xsd:string ;
+	skos:definition "The base unit for measuring the amount of digital information."^^xsd:string ;
 	skos:prefLabel "bit"^^xsd:string ;
 	skos:scopeNote "A bit (short for binary digit) is the smallest unit of data in a computer. A bit has a single binary value, either 0 or 1."^^xsd:string ;
 	gist:conversionFactor "1.0"^^xsd:double ;

--- a/gistCore.ttl
+++ b/gistCore.ttl
@@ -316,29 +316,6 @@ gist:CoherentRatioUnit
 	skos:prefLabel "Coherent Ratio Unit"^^xsd:string ;
 	.
 
-gist:CoherentUnit
-	a owl:Class ;
-	rdfs:seeAlso <http://www.eim.gr/metrology/measurement-units/si-derived-units/coherent-derived-units/> ;
-	owl:equivalentClass [
-		a owl:Class ;
-		owl:unionOf (
-			gist:BaseUnit
-			gist:CoherentProductUnit
-			gist:CoherentRatioUnit
-		) ;
-	] ;
-	skos:definition "A unit that is expressed in units that have no conversions.  It may be a simple unit.  It may also be a product or ratio unit that bottoms out in simple units."^^xsd:string ;
-	skos:example
-		"A simple unit: kilogram"^^xsd:string ,
-		"The standard unit for acceleration is meters per square second (feet per square second  requires a conversion)"^^xsd:string
-		;
-	skos:prefLabel "Coherent Unit"^^xsd:string ;
-	skos:scopeNote
-		"Coherent unit is the physics term for this, informally you might think of it as the standard unit for a given dimension."^^xsd:string ,
-		"In principle, the CoherentUnit for a ProductUnit or RatioUnit can be inferred by recursively decomposing the products and ratios into their respective CoherentUnits, bottoming out in SimpleUnits"^^xsd:string
-		;
-	.
-
 gist:Collection
 	a owl:Class ;
 	skos:definition "A grouping of things."^^xsd:string ;
@@ -969,8 +946,7 @@ gist:GeoPoint
 		gist:Magnitude ,
 		gist:Organization ,
 		gist:PhysicalIdentifiableItem ,
-		gist:PhysicalSubstance ,
-		gist:UnitOfMeasure
+		gist:PhysicalSubstance
 		;
 	owl:equivalentClass [
 		a owl:Class ;
@@ -1007,8 +983,7 @@ gist:GeoRegion
 		gist:Organization ,
 		gist:PhysicalIdentifiableItem ,
 		gist:PhysicalSubstance ,
-		gist:Template ,
-		gist:UnitOfMeasure
+		gist:Template
 		;
 	owl:equivalentClass [
 		a owl:Class ;
@@ -1211,8 +1186,7 @@ gist:IntellectualProperty
 		gist:Magnitude ,
 		gist:Organization ,
 		gist:PhysicalIdentifiableItem ,
-		gist:PhysicalSubstance ,
-		gist:UnitOfMeasure
+		gist:PhysicalSubstance
 		;
 	skos:definition "A work, invention or concept, independent of its being expressed in text, audio, video, image, or live performance.  IP can also be tacit knowledge, know-how, or skill. Also includes Brands."^^xsd:string ;
 	skos:example "The Old Man and The Sea; the Page Rank algorithm; Coca Cola"^^xsd:string ;
@@ -1226,8 +1200,7 @@ gist:Intention
 		gist:Magnitude ,
 		gist:Organization ,
 		gist:PhysicalIdentifiableItem ,
-		gist:PhysicalSubstance ,
-		gist:UnitOfMeasure
+		gist:PhysicalSubstance
 		;
 	skos:definition 'Goal, desire, aspiration. This is the "teleologic" aspect of the system that indicates things are done with a purpose.'^^xsd:string ;
 	skos:prefLabel "Intention"^^xsd:string ;
@@ -1282,8 +1255,7 @@ gist:Language
 		gist:Magnitude ,
 		gist:Organization ,
 		gist:PhysicalIdentifiableItem ,
-		gist:PhysicalSubstance ,
-		gist:UnitOfMeasure
+		gist:PhysicalSubstance
 		;
 	skos:definition "A recognized, organized set of symbols and grammar."^^xsd:string ;
 	skos:example "Natural languages such as English and Spanish; computer languages such as OWL, Python, and XML."^^xsd:string ;
@@ -1361,8 +1333,7 @@ gist:Magnitude
 	owl:disjointWith
 		gist:Organization ,
 		gist:PhysicalIdentifiableItem ,
-		gist:PhysicalSubstance ,
-		gist:UnitOfMeasure
+		gist:PhysicalSubstance
 		;
 	owl:equivalentClass [
 		a owl:Class ;
@@ -2191,6 +2162,32 @@ gist:Specification
 	skos:prefLabel "Specification"^^xsd:string ;
 	.
 
+gist:StandardUnit
+	a owl:Class ;
+	rdfs:seeAlso <http://www.eim.gr/metrology/measurement-units/si-derived-units/coherent-derived-units/> ;
+	owl:equivalentClass [
+		a owl:Class ;
+		owl:intersectionOf (
+			gist:UnitOfMeasure
+			[
+				a owl:Restriction ;
+				owl:onProperty gist:hasStandardUnit ;
+				owl:hasSelf "true"^^xsd:boolean ;
+			]
+			[
+				a owl:Restriction ;
+				owl:onProperty gist:convertToStandard ;
+				owl:hasValue "1"^^xsd:double ;
+			]
+		) ;
+	] ;
+	skos:altLabel "Conherent Unit"^^xsd:string ;
+	skos:definition "A unit that has itself as a standard unit and has no conversions."^^xsd:string ;
+	skos:example "kilogram (for mass); meters per square second (for acceleration)"^^xsd:string ;
+	skos:prefLabel "Standard Unit"^^xsd:string ;
+	skos:scopeNote "Coherent unit is the physics term for this, informally you might think of it as the standard unit for a given dimension."^^xsd:string ;
+	.
+
 gist:StreetAddress
 	a owl:Class ;
 	rdfs:subClassOf gist:PostalAddress ;
@@ -2509,7 +2506,33 @@ gist:TreatyOrganization
 
 gist:UnitOfMeasure
 	a owl:Class ;
-	skos:definition "Standard unit by which we measure things"^^xsd:string ;
+	owl:equivalentClass [
+		a owl:Class ;
+		owl:intersectionOf (
+			gist:Magnitude
+			[
+				a owl:Restriction ;
+				owl:onProperty gist:hasUnitOfMeasure ;
+				owl:hasSelf "true"^^xsd:boolean ;
+			]
+			[
+				a owl:Restriction ;
+				owl:onProperty gist:conversionFactor ;
+				owl:someValuesFrom xsd:double ;
+			]
+			[
+				a owl:Restriction ;
+				owl:onProperty gist:hasStandardUnit ;
+				owl:someValuesFrom gist:StandardUnit ;
+			]
+			[
+				a owl:Restriction ;
+				owl:onProperty gist:numericValue ;
+				owl:hasValue "1"^^xsd:double ;
+			]
+		) ;
+	] ;
+	skos:definition "A magnitude intended for use as a unit for other magnitudes. A unit of measure always has itself as a unit, a decimalValuel of 1, a standard unit and a conversion to that standard unit."^^xsd:string ;
 	skos:prefLabel "Unit of Measure"^^xsd:string ;
 	.
 
@@ -3357,7 +3380,7 @@ gist:hasRecipient
 gist:hasStandardUnit
 	a owl:ObjectProperty ;
 	rdfs:domain gist:UnitOfMeasure ;
-	rdfs:range gist:CoherentUnit ;
+	rdfs:range gist:StandardUnit ;
 	skos:definition "For a complex unit refers to a unit that has all the component parts in SI"^^xsd:string ;
 	skos:prefLabel "has standard unit"^^xsd:string ;
 	.

--- a/gistCore.ttl
+++ b/gistCore.ttl
@@ -99,7 +99,7 @@ gist:AreaUnit
 	owl:equivalentClass [
 		a owl:Class ;
 		owl:intersectionOf (
-			gist:ProductUnit
+			gist:UnitOfMeasure
 			[
 				a owl:Restriction ;
 				owl:onProperty gist:hasMultiplicand ;
@@ -1128,7 +1128,7 @@ gist:Intention
 		gist:PhysicalIdentifiableItem ,
 		gist:PhysicalSubstance
 		;
-	skos:definition 'Goal, desire, aspiration. This is the "teleologic" aspect of the system that indicates things are done with a purpose.'^^xsd:string ;
+	skos:definition "Goal, desire, aspiration. This is the 'teleologic' aspect of the system that indicates things are done with a purpose."^^xsd:string ;
 	skos:prefLabel "Intention"^^xsd:string ;
 	.
 
@@ -1281,7 +1281,8 @@ gist:Magnitude
 			]
 		) ;
 	] ;
-	skos:definition "Base class for units which can be converted.  The primitive units can be converted from one measurement system to another; the complex units (ratio or product) have to decompose to their primitives."^^xsd:string ;
+	skos:definition "A quantity consisting of a UnitOfMeasure and a numeric value and a precision."^^xsd:string ;
+	skos:example "3.2 kilometers; 4 litres, 4 amperes"^^xsd:string ;
 	skos:prefLabel "Magnitude"^^xsd:string ;
 	skos:scopeNote
 		"Magnitudes of the same dimensional type (i.e., duration or electric current) can be compared with a greater-than or less-than operator, but can still differ in their relationToTheWorld type.  (I.e., you can compare actuals to estimates or references, so long as the dimension is the same.)"^^xsd:string ,
@@ -1671,8 +1672,33 @@ gist:Organization
 
 gist:Percentage
 	a owl:Class ;
-	rdfs:subClassOf gist:RatioMagnitude ;
-	skos:definition "A ratio where the numerator and denominator are of the same unit of measure."^^xsd:string ;
+	rdfs:subClassOf [
+		a owl:Class ;
+		owl:intersectionOf (
+			gist:Magnitude
+			[
+				a owl:Restriction ;
+				owl:onProperty gist:hasUnitOfMeasure ;
+				owl:someValuesFrom [
+					a owl:Class ;
+					owl:intersectionOf (
+						gist:UnitOfMeasure
+						[
+							a owl:Restriction ;
+							owl:onProperty gist:hasDenominator ;
+							owl:someValuesFrom gist:UnitOfMeasure ;
+						]
+						[
+							a owl:Restriction ;
+							owl:onProperty gist:hasNumerator ;
+							owl:someValuesFrom gist:UnitOfMeasure ;
+						]
+					) ;
+				] ;
+			]
+		) ;
+	] ;
+	skos:definition "A Magnitude with a unit of measure that is a ratio where the numerator and denominator are of the same unit of measure."^^xsd:string ;
 	skos:prefLabel "Percentage"^^xsd:string ;
 	skos:scopeNote "There are various ways to represent percentage: 50/100 could be represented as ?50? or ?0.5?.  gist uses the latter, as it involves fewer conversions for subsequent use."^^xsd:string ;
 	.
@@ -2376,6 +2402,7 @@ gist:UnitOfMeasure
 	] ;
 	skos:definition "A magnitude intended for use as a unit for other magnitudes. A unit of measure always has itself as a unit, a decimalValuel of 1, a standard unit and a conversion to that standard unit."^^xsd:string ;
 	skos:prefLabel "Unit of Measure"^^xsd:string ;
+	skos:scopeNote "The primitive units can be converted from one measurement system to another; the complex units composed of products and/or ratios of other units have to decompose to their primitives."^^xsd:string ;
 	.
 
 gist:Volume
@@ -2400,7 +2427,7 @@ gist:VolumeUnit
 	owl:equivalentClass [
 		a owl:Class ;
 		owl:intersectionOf (
-			gist:ProductUnit
+			gist:UnitOfMeasure
 			[
 				a owl:Restriction ;
 				owl:onProperty gist:hasMultiplicand ;
@@ -3119,13 +3146,13 @@ gist:hasMember
 
 gist:hasMultiplicand
 	a owl:ObjectProperty ;
-	skos:definition "Relates a ProductUnit such as square mile to the second of two units multiplied together (e.g. mile)."^^xsd:string ;
+	skos:definition "Relates a unit of measure such as square mile to the second of two units multiplied together (e.g. mile)."^^xsd:string ;
 	skos:prefLabel "has multiplicand"^^xsd:string ;
 	.
 
 gist:hasMultiplier
 	a owl:ObjectProperty ;
-	skos:definition "Relates a ProductUnit such as square mile to the first of two units multiplied together (e.g. mile)"^^xsd:string ;
+	skos:definition "Relates a unit of measure such as square mile to the first of two units multiplied together (e.g. mile)"^^xsd:string ;
 	skos:prefLabel "has multiplier"^^xsd:string ;
 	.
 

--- a/gistCore.ttl
+++ b/gistCore.ttl
@@ -3248,7 +3248,10 @@ gist:hasRecipient
 	.
 
 gist:hasStandardUnit
-	a owl:ObjectProperty ;
+	a
+		owl:ObjectProperty ,
+		owl:FunctionalProperty
+		;
 	rdfs:domain gist:UnitOfMeasure ;
 	rdfs:range gist:StandardUnit ;
 	skos:definition "For a complex unit refers to a unit that has all the component parts in SI"^^xsd:string ;

--- a/gistCore.ttl
+++ b/gistCore.ttl
@@ -640,6 +640,23 @@ gist:DegreeOfCommitment
 	skos:prefLabel "Degree Of Commitment"^^xsd:string ;
 	.
 
+gist:Distance
+	a owl:Class ;
+	owl:equivalentClass [
+		a owl:Class ;
+		owl:intersectionOf (
+			gist:Magnitude
+			[
+				a owl:Restriction ;
+				owl:onProperty gist:hasUnitOfMeasure ;
+				owl:someValuesFrom gist:DistanceUnit ;
+			]
+		) ;
+	] ;
+	skos:definition "A measure of distance, which could be distances over the Earth, and could also be height, width, length, depth, girth, etc."^^xsd:string ;
+	skos:prefLabel "Extent"^^xsd:string ;
+	.
+
 gist:DistanceUnit
 	a owl:Class ;
 	owl:disjointWith

--- a/gistCore.ttl
+++ b/gistCore.ttl
@@ -2432,8 +2432,7 @@ gist:_PrefixDeclaration_gist
 gist:_USDollar
 	a
 		owl:NamedIndividual ,
-		owl:Thing ,
-		gist:BaseUnit
+		owl:Thing
 		;
 	skos:definition "The base unit for currency."^^xsd:string ;
 	skos:prefLabel "US Dollar"^^xsd:string ;
@@ -2445,8 +2444,7 @@ gist:_USDollar
 gist:_ampere
 	a
 		owl:NamedIndividual ,
-		owl:Thing ,
-		gist:BaseUnit
+		owl:Thing
 		;
 	skos:definition "The base unit for electrical current."^^xsd:string ;
 	skos:prefLabel "ampere"^^xsd:string ;
@@ -2458,8 +2456,7 @@ gist:_ampere
 gist:_bit
 	a
 		owl:NamedIndividual ,
-		owl:Thing ,
-		gist:BaseUnit
+		owl:Thing
 		;
 	skos:definition "The base unit for measuring digital information."^^xsd:string ;
 	skos:prefLabel "bit"^^xsd:string ;
@@ -2471,8 +2468,7 @@ gist:_bit
 gist:_candela
 	a
 		owl:NamedIndividual ,
-		owl:Thing ,
-		gist:BaseUnit
+		owl:Thing
 		;
 	skos:definition "The base unit for luminous intensity."^^xsd:string ;
 	skos:prefLabel "candela"^^xsd:string ;
@@ -2495,8 +2491,7 @@ gist:_day
 gist:_each
 	a
 		owl:NamedIndividual ,
-		owl:Thing ,
-		gist:BaseUnit
+		owl:Thing
 		;
 	skos:definition "The base unit for count magnitudes."^^xsd:string ;
 	skos:prefLabel "each"^^xsd:string ;
@@ -2507,8 +2502,7 @@ gist:_each
 gist:_kelvin
 	a
 		owl:NamedIndividual ,
-		owl:Thing ,
-		gist:BaseUnit
+		owl:Thing
 		;
 	skos:definition "The base unit for measuring temperature."^^xsd:string ;
 	skos:prefLabel "Kelvin"^^xsd:string ;
@@ -2521,8 +2515,7 @@ gist:_kelvin
 gist:_kilogram
 	a
 		owl:NamedIndividual ,
-		owl:Thing ,
-		gist:BaseUnit
+		owl:Thing
 		;
 	skos:definition "The base unit for measuring mass."^^xsd:string ;
 	skos:prefLabel "mass"^^xsd:string ;
@@ -2534,8 +2527,7 @@ gist:_kilogram
 gist:_meter
 	a
 		owl:NamedIndividual ,
-		owl:Thing ,
-		gist:BaseUnit
+		owl:Thing
 		;
 	skos:definition "The base unit for measuring distance."^^xsd:string ;
 	skos:prefLabel "distance"^^xsd:string ;
@@ -2571,8 +2563,7 @@ gist:_minute
 gist:_mole
 	a
 		owl:NamedIndividual ,
-		owl:Thing ,
-		gist:BaseUnit
+		owl:Thing
 		;
 	skos:definition "The base unit for measuring molar quantities."^^xsd:string ;
 	skos:prefLabel "mole"^^xsd:string ;
@@ -2584,8 +2575,7 @@ gist:_mole
 gist:_second
 	a
 		owl:NamedIndividual ,
-		owl:Thing ,
-		gist:BaseUnit
+		owl:Thing
 		;
 	skos:definition "The base unit for measuring durations."^^xsd:string ;
 	skos:prefLabel "second"^^xsd:string ;

--- a/gistCore.ttl
+++ b/gistCore.ttl
@@ -112,6 +112,11 @@ gist:AreaUnit
 				owl:onClass gist:DistanceUnit ;
 				owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			]
+			[
+				a owl:Restriction ;
+				owl:onProperty gist:hasStandardUnit ;
+				owl:hasValue gist:_square_meter ;
+			]
 		) ;
 	] ;
 	skos:definition "A unit of two-dimensional area, such as square inches or hectares."^^xsd:string ;
@@ -2021,7 +2026,7 @@ gist:StandardUnit
 			]
 			[
 				a owl:Restriction ;
-				owl:onProperty gist:convertToStandard ;
+				owl:onProperty gist:conversionFactor ;
 				owl:hasValue "1"^^xsd:double ;
 			]
 		) ;
@@ -2417,6 +2422,11 @@ gist:VolumeUnit
 				owl:onClass gist:DistanceUnit ;
 				owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			]
+			[
+				a owl:Restriction ;
+				owl:onProperty gist:hasStandardUnit ;
+				owl:hasValue gist:_cubic_meter ;
+			]
 		) ;
 	] ;
 	skos:definition "Units of three-dimensional space, expressed here as an area times a distance."^^xsd:string ;
@@ -2475,6 +2485,18 @@ gist:_candela
 	gist:conversionFactor "1.0"^^xsd:double ;
 	gist:hasStandardUnit gist:_candela ;
 	gist:unitSymbol "cd"^^xsd:string ;
+	.
+
+gist:_cubic_meter
+	a
+		owl:Thing ,
+		gist:VolumeUnit
+		;
+	gist:conversionFactor "1.0"^^xsd:double ;
+	gist:hasMultiplicand gist:_square_meter ;
+	gist:hasMultiplier gist:_meter ;
+	gist:hasStandardUnit gist:_cubic_meter ;
+	gist:unitSymbol "m^3"^^xsd:string ;
 	.
 
 gist:_day
@@ -2582,6 +2604,18 @@ gist:_second
 	gist:conversionFactor "1.0"^^xsd:double ;
 	gist:hasStandardUnit gist:_second ;
 	gist:unitSymbol "s"^^xsd:string ;
+	.
+
+gist:_square_meter
+	a
+		owl:Thing ,
+		gist:AreaUnit
+		;
+	gist:conversionFactor "1.0"^^xsd:double ;
+	gist:hasMultiplicand gist:_meter ;
+	gist:hasMultiplier gist:_meter ;
+	gist:hasStandardUnit gist:_square_meter ;
+	gist:unitSymbol "m^2"^^xsd:string ;
 	.
 
 gist:accepts

--- a/gistCore.ttl
+++ b/gistCore.ttl
@@ -131,7 +131,7 @@ gist:Artifact
 
 gist:Aspect
 	a owl:Class ;
-	rdfs:subClassOf gist:Category ;
+	rdfs:subClassOf gist:SchemaMetaData ;
 	skos:definition "A very general term for the characteristic of something that is being measured.  E.g., property (height) or a process (cycle time) or a behavior (loyalty)."^^xsd:string ;
 	skos:prefLabel "Aspect"^^xsd:string ;
 	.
@@ -240,80 +240,6 @@ gist:Category
 	skos:example "Tags used in folksonomies; formal definitions from other systems."^^xsd:string ;
 	skos:prefLabel "Category"^^xsd:string ;
 	skos:scopeNote "Often a 'bucket' can be modeled either as an owl:Class or as a gist:Category. Use the latter if you don't care much about the formal structure of the different types, or if there is a whole hierarchy of types that are going to be managed by a group separate from the ontology developers. The formal structure may be defined elsewhere and linked to, if necessary."^^xsd:string ;
-	.
-
-gist:CoherentProductUnit
-	a owl:Class ;
-	owl:equivalentClass [
-		a owl:Class ;
-		owl:intersectionOf (
-			gist:ProductUnit
-			[
-				a owl:Restriction ;
-				owl:onProperty gist:hasMultiplicand ;
-				owl:allValuesFrom [
-					a owl:Class ;
-					owl:unionOf (
-						gist:BaseUnit
-						gist:CoherentProductUnit
-						gist:CoherentRatioUnit
-					) ;
-				] ;
-			]
-			[
-				a owl:Restriction ;
-				owl:onProperty gist:hasMultiplier ;
-				owl:allValuesFrom [
-					a owl:Class ;
-					owl:unionOf (
-						gist:BaseUnit
-						gist:CoherentProductUnit
-						gist:CoherentRatioUnit
-					) ;
-				] ;
-			]
-		) ;
-	] ;
-	skos:definition "A product unit both of whose factors are coherent units. The conversion factor is 1."^^xsd:string ;
-	skos:example "Square meter, an area unit."^^xsd:string ;
-	skos:prefLabel "Coherent Product Unit"^^xsd:string ;
-	.
-
-gist:CoherentRatioUnit
-	a owl:Class ;
-	owl:equivalentClass [
-		a owl:Class ;
-		owl:intersectionOf (
-			gist:RatioUnit
-			[
-				a owl:Restriction ;
-				owl:onProperty gist:hasDenominator ;
-				owl:allValuesFrom [
-					a owl:Class ;
-					owl:unionOf (
-						gist:BaseUnit
-						gist:CoherentProductUnit
-						gist:CoherentRatioUnit
-					) ;
-				] ;
-			]
-			[
-				a owl:Restriction ;
-				owl:onProperty gist:hasNumerator ;
-				owl:allValuesFrom [
-					a owl:Class ;
-					owl:unionOf (
-						gist:BaseUnit
-						gist:CoherentProductUnit
-						gist:CoherentRatioUnit
-					) ;
-				] ;
-			]
-		) ;
-	] ;
-	skos:definition "A ratio unit whose conversion factor is 1."^^xsd:string ;
-	skos:example "Newton, a force unit also expressed as kg-m/s^2"^^xsd:string ;
-	skos:prefLabel "Coherent Ratio Unit"^^xsd:string ;
 	.
 
 gist:Collection
@@ -1917,23 +1843,6 @@ gist:ProductCategory
 	skos:prefLabel "Product Category"^^xsd:string ;
 	.
 
-gist:ProductMagnitude
-	a owl:Class ;
-	owl:equivalentClass [
-		a owl:Class ;
-		owl:intersectionOf (
-			gist:Magnitude
-			[
-				a owl:Restriction ;
-				owl:onProperty gist:hasUnitOfMeasure ;
-				owl:someValuesFrom gist:ProductUnit ;
-			]
-		) ;
-	] ;
-	skos:definition "A magnitude expressed as a product of primitives.  (E.g., Force = M*A)."^^xsd:string ;
-	skos:prefLabel "Product Magnitude"^^xsd:string ;
-	.
-
 gist:ProductSpecification
 	a owl:Class ;
 	owl:equivalentClass [
@@ -1951,30 +1860,6 @@ gist:ProductSpecification
 	skos:prefLabel "Product Specification"^^xsd:string ;
 	.
 
-gist:ProductUnit
-	a owl:Class ;
-	owl:equivalentClass [
-		a owl:Class ;
-		owl:intersectionOf (
-			gist:UnitOfMeasure
-			[
-				a owl:Restriction ;
-				owl:onProperty gist:hasMultiplicand ;
-				owl:someValuesFrom gist:UnitOfMeasure ;
-			]
-			[
-				a owl:Restriction ;
-				owl:onProperty gist:hasMultiplier ;
-				owl:someValuesFrom gist:UnitOfMeasure ;
-			]
-		) ;
-	] ;
-	skos:definition "A unit of measure that is the product of two simpler ones."^^xsd:string ;
-	skos:example "Area and Volume are the classic cases.  But other, more exotic cases exist, such as Newtons."^^xsd:string ;
-	skos:prefLabel "Product Unit"^^xsd:string ;
-	skos:scopeNote "A ProductUnit is intended have a value for conversionFactor."^^xsd:string ;
-	.
-
 gist:ProjectExecution
 	a owl:Class ;
 	owl:equivalentClass [
@@ -1990,49 +1875,6 @@ gist:ProjectExecution
 	] ;
 	skos:definition "A project execution is a task execution (usually a longer duration task) made up of other task executions."^^xsd:string ;
 	skos:prefLabel "Project Execution"^^xsd:string ;
-	.
-
-gist:RatioMagnitude
-	a owl:Class ;
-	owl:equivalentClass [
-		a owl:Class ;
-		owl:intersectionOf (
-			gist:Magnitude
-			[
-				a owl:Restriction ;
-				owl:onProperty gist:hasUnitOfMeasure ;
-				owl:someValuesFrom gist:RatioUnit ;
-			]
-		) ;
-	] ;
-	skos:definition "This is a number whose unit of measure is a ratio."^^xsd:string ;
-	skos:example "Speed.  The ratio magnitude is 60, the unit of measure might be MilesPerHour."^^xsd:string ;
-	skos:prefLabel "Ratio Magnitude"^^xsd:string ;
-	skos:scopeNote "A RatioMagnitude just has one decimal value."^^xsd:string ;
-	.
-
-gist:RatioUnit
-	a owl:Class ;
-	owl:equivalentClass [
-		a owl:Class ;
-		owl:intersectionOf (
-			gist:UnitOfMeasure
-			[
-				a owl:Restriction ;
-				owl:onProperty gist:hasDenominator ;
-				owl:someValuesFrom gist:UnitOfMeasure ;
-			]
-			[
-				a owl:Restriction ;
-				owl:onProperty gist:hasNumerator ;
-				owl:someValuesFrom gist:UnitOfMeasure ;
-			]
-		) ;
-	] ;
-	skos:definition "A UnitOfMeasure composed of a numerator unit and a denominator unit."^^xsd:string ;
-	skos:example "Miles per hour."^^xsd:string ;
-	skos:prefLabel "Ratio Unit"^^xsd:string ;
-	skos:scopeNote "If needed, a conversion factor for a RatioUnit can be (recursively) derived from the conversion factors of the numerator and denominator units.  E.g., the derived conversion factor from km/minute to meters/second is 1000/60 or 16 2/3."^^xsd:string ;
 	.
 
 gist:ReferenceValue
@@ -3368,6 +3210,7 @@ gist:hasPrecision
 	skos:definition "Links a Magnitude to the degree of accuracy of the numeric value.   This allows for fuzzy numbers.  All magnitudes have a precision.  Usually we don't record them.  When we do this, it will be a value whose extent covers 2 standard deviations around the stated magnitude"^^xsd:string ;
 	skos:example "Temperature precise to tenth of a degree C; length precise to the nearest centimeter."^^xsd:string ;
 	skos:prefLabel "has precision"^^xsd:string ;
+	skos:scopeNote "The precision must have the same standard unit as the magnitude."^^xsd:string ;
 	.
 
 gist:hasRecipient

--- a/gistCore.ttl
+++ b/gistCore.ttl
@@ -155,7 +155,7 @@ gist:Balance
 
 gist:BaseUnit
 	a owl:Class ;
-	rdfs:subClassOf gist:SimpleUnitOfMeasure ;
+	rdfs:subClassOf gist:UnitOfMeasure ;
 	owl:equivalentClass [
 		a owl:Class ;
 		owl:oneOf (
@@ -523,7 +523,7 @@ gist:CountingUnit
 	owl:equivalentClass [
 		a owl:Class ;
 		owl:intersectionOf (
-			gist:SimpleUnitOfMeasure
+			gist:UnitOfMeasure
 			[
 				a owl:Restriction ;
 				owl:onProperty gist:hasBaseUnit ;
@@ -594,7 +594,7 @@ gist:CurrencyUnit
 	owl:equivalentClass [
 		a owl:Class ;
 		owl:intersectionOf (
-			gist:SimpleUnitOfMeasure
+			gist:UnitOfMeasure
 			[
 				a owl:Restriction ;
 				owl:onProperty gist:hasBaseUnit ;
@@ -620,7 +620,7 @@ gist:DataSizeUnit
 	owl:equivalentClass [
 		a owl:Class ;
 		owl:intersectionOf (
-			gist:SimpleUnitOfMeasure
+			gist:UnitOfMeasure
 			[
 				a owl:Restriction ;
 				owl:onProperty gist:hasBaseUnit ;
@@ -653,7 +653,7 @@ gist:DistanceUnit
 	owl:equivalentClass [
 		a owl:Class ;
 		owl:intersectionOf (
-			gist:SimpleUnitOfMeasure
+			gist:UnitOfMeasure
 			[
 				a owl:Restriction ;
 				owl:onProperty gist:hasBaseUnit ;
@@ -696,7 +696,7 @@ gist:DurationUnit
 	owl:equivalentClass [
 		a owl:Class ;
 		owl:intersectionOf (
-			gist:SimpleUnitOfMeasure
+			gist:UnitOfMeasure
 			[
 				a owl:Restriction ;
 				owl:onProperty gist:hasBaseUnit ;
@@ -736,7 +736,7 @@ gist:ElectricalCurrentUnit
 	owl:equivalentClass [
 		a owl:Class ;
 		owl:intersectionOf (
-			gist:SimpleUnitOfMeasure
+			gist:UnitOfMeasure
 			[
 				a owl:Restriction ;
 				owl:onProperty gist:hasBaseUnit ;
@@ -1242,7 +1242,7 @@ gist:LuminousIntensityUnit
 	owl:equivalentClass [
 		a owl:Class ;
 		owl:intersectionOf (
-			gist:SimpleUnitOfMeasure
+			gist:UnitOfMeasure
 			[
 				a owl:Restriction ;
 				owl:onProperty gist:hasBaseUnit ;
@@ -1316,7 +1316,7 @@ gist:MassUnit
 	owl:equivalentClass [
 		a owl:Class ;
 		owl:intersectionOf (
-			gist:SimpleUnitOfMeasure
+			gist:UnitOfMeasure
 			[
 				a owl:Restriction ;
 				owl:onProperty gist:hasBaseUnit ;
@@ -1408,7 +1408,7 @@ gist:MoleUnit
 	owl:equivalentClass [
 		a owl:Class ;
 		owl:intersectionOf (
-			gist:SimpleUnitOfMeasure
+			gist:UnitOfMeasure
 			[
 				a owl:Restriction ;
 				owl:onProperty gist:hasBaseUnit ;
@@ -2000,29 +2000,6 @@ gist:ServiceSpecification
 	skos:prefLabel "Service Specification"^^xsd:string ;
 	.
 
-gist:SimpleUnitOfMeasure
-	a owl:Class ;
-	owl:equivalentClass [
-		a owl:Class ;
-		owl:intersectionOf (
-			gist:UnitOfMeasure
-			[
-				a owl:Restriction ;
-				owl:onProperty gist:hasBaseUnit ;
-				owl:onClass gist:BaseUnit ;
-				owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
-			]
-			[
-				a owl:Restriction ;
-				owl:onProperty gist:conversionFactor ;
-				owl:someValuesFrom xsd:double ;
-			]
-		) ;
-	] ;
-	skos:definition "Each simple unit has a base unit and a conversion factor to the base. The bases are from the System International (SI). The conversion factor is the number which one multiplies a Unit by to get to base, or divides by to get from base.  E.g., the conversionFactor for inch is 0.0254 to get to the base unit (meter)."^^xsd:string ;
-	skos:prefLabel "Simple Unit Of Measure"^^xsd:string ;
-	.
-
 gist:Specification
 	a owl:Class ;
 	rdfs:subClassOf gist:Requirement ;
@@ -2228,7 +2205,7 @@ gist:TemperatureUnit
 	owl:equivalentClass [
 		a owl:Class ;
 		owl:intersectionOf (
-			gist:SimpleUnitOfMeasure
+			gist:UnitOfMeasure
 			[
 				a owl:Restriction ;
 				owl:onProperty gist:hasBaseUnit ;

--- a/gistCore.ttl
+++ b/gistCore.ttl
@@ -522,7 +522,7 @@ gist:Count
 			[
 				a owl:Restriction ;
 				owl:onProperty gist:hasUnitOfMeasure ;
-				owl:someValuesFrom gist:CountingUnit ;
+				owl:someValuesFrom gist:CountUnit ;
 			]
 		) ;
 	] ;
@@ -531,7 +531,7 @@ gist:Count
 	skos:scopeNote "Count is not disjoint with all the other magnitudes, as there are some magnitudes that could conceivably be counted."^^xsd:string ;
 	.
 
-gist:CountingUnit
+gist:CountUnit
 	a owl:Class ;
 	owl:equivalentClass [
 		a owl:Class ;
@@ -544,8 +544,8 @@ gist:CountingUnit
 			]
 		) ;
 	] ;
-	skos:definition "A unit of counting, especially ?each?, but also units such as dozens."^^xsd:string ;
-	skos:prefLabel "Counting Unit"^^xsd:string ;
+	skos:definition "A unit of counting, especially ?each?, but also units such as dozen."^^xsd:string ;
+	skos:prefLabel "Count Unit"^^xsd:string ;
 	.
 
 gist:CountryGeoRegion
@@ -1398,7 +1398,7 @@ gist:MessageDefinition
 	skos:prefLabel "Message Definition"^^xsd:string ;
 	.
 
-gist:MolarQuantity
+gist:MoleQuantity
 	a owl:Class ;
 	owl:equivalentClass [
 		a owl:Class ;
@@ -1412,7 +1412,7 @@ gist:MolarQuantity
 		) ;
 	] ;
 	skos:definition "Amount of a substance, as counted molecules."^^xsd:string ;
-	skos:prefLabel "Molar Quantity"^^xsd:string ;
+	skos:prefLabel "Mole Quantity"^^xsd:string ;
 	.
 
 gist:MoleUnit
@@ -2603,7 +2603,7 @@ gist:_mole
 		owl:NamedIndividual ,
 		owl:Thing
 		;
-	skos:definition "The base unit for measuring molar quantities."^^xsd:string ;
+	skos:definition "The base unit for measuring mole quantities."^^xsd:string ;
 	skos:prefLabel "mole"^^xsd:string ;
 	gist:conversionFactor "1.0"^^xsd:double ;
 	gist:hasStandardUnit gist:_mole ;

--- a/gistCore.ttl
+++ b/gistCore.ttl
@@ -2568,7 +2568,7 @@ gist:_meter
 		owl:Thing
 		;
 	skos:definition "The base unit for measuring distance."^^xsd:string ;
-	skos:prefLabel "distance"^^xsd:string ;
+	skos:prefLabel "meter"^^xsd:string ;
 	gist:conversionFactor "1.0"^^xsd:double ;
 	gist:hasStandardUnit gist:_meter ;
 	gist:unitSymbol "m"^^xsd:string ;

--- a/gistDeprecated.ttl
+++ b/gistDeprecated.ttl
@@ -17,6 +17,30 @@
 	gist:license "https://creativecommons.org/licenses/by-sa/3.0/"^^xsd:string ;
 	.
 
+gist:CoherentUnit
+	a owl:Class ;
+	rdfs:seeAlso <http://www.eim.gr/metrology/measurement-units/si-derived-units/coherent-derived-units/> ;
+	owl:deprecated "true"^^xsd:boolean ;
+	owl:equivalentClass [
+		a owl:Class ;
+		owl:unionOf (
+			gist:BaseUnit
+			gist:CoherentProductUnit
+			gist:CoherentRatioUnit
+		) ;
+	] ;
+	skos:definition "A unit that is expressed in units that have no conversions.  It may be a simple unit.  It may also be a product or ratio unit that bottoms out in simple units."^^xsd:string ;
+	skos:example
+		"A simple unit: kilogram"^^xsd:string ,
+		"The standard unit for acceleration is meters per square second (feet per square second  requires a conversion)"^^xsd:string
+		;
+	skos:prefLabel "Coherent Unit"^^xsd:string ;
+	skos:scopeNote
+		"Coherent unit is the physics term for this, informally you might think of it as the standard unit for a given dimension."^^xsd:string ,
+		"In principle, the CoherentUnit for a ProductUnit or RatioUnit can be inferred by recursively decomposing the products and ratios into their respective CoherentUnits, bottoming out in SimpleUnits"^^xsd:string
+		;
+	.
+
 gist:Group
 	a owl:Class ;
 	owl:deprecated "true"^^xsd:boolean ;

--- a/gistDeprecated.ttl
+++ b/gistDeprecated.ttl
@@ -187,3 +187,14 @@ gist:_one_minute
 	gist:numericValue "1.0"^^xsd:double ;
 	.
 
+gist:hasBaseUnit
+	a owl:ObjectProperty ;
+	rdfs:subPropertyOf gist:hasStandardUnit ;
+	rdfs:domain gist:UnitOfMeasure ;
+	rdfs:range gist:BaseUnit ;
+	owl:deprecated "true"^^xsd:boolean ;
+	skos:definition "Relates a UnitOfMeasure to its BaseUnit.  This indicates what kind of Unit something is."^^xsd:string ;
+	skos:example "Saying that a furlong hasBaseUnit  meter says it is a DistanceUnit."^^xsd:string ;
+	skos:prefLabel "has base unit"^^xsd:string ;
+	.
+

--- a/gistDeprecated.ttl
+++ b/gistDeprecated.ttl
@@ -91,6 +91,30 @@ gist:ScheduledTask
 	skos:prefLabel "Scheduled Task"^^xsd:string ;
 	.
 
+gist:SimpleUnitOfMeasure
+	a owl:Class ;
+	owl:deprecated "true"^^xsd:boolean ;
+	owl:equivalentClass [
+		a owl:Class ;
+		owl:intersectionOf (
+			gist:UnitOfMeasure
+			[
+				a owl:Restriction ;
+				owl:onProperty gist:hasBaseUnit ;
+				owl:onClass gist:BaseUnit ;
+				owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+			]
+			[
+				a owl:Restriction ;
+				owl:onProperty gist:conversionFactor ;
+				owl:someValuesFrom xsd:double ;
+			]
+		) ;
+	] ;
+	skos:definition "Each simple unit has a base unit and a conversion factor to the base. The bases are from the System International (SI). The conversion factor is the number which one multiplies a Unit by to get to base, or divides by to get from base.  E.g., the conversionFactor for inch is 0.0254 to get to the base unit (meter)."^^xsd:string ;
+	skos:prefLabel "Simple Unit Of Measure"^^xsd:string ;
+	.
+
 gist:Task
 	a owl:Class ;
 	owl:deprecated "true"^^xsd:boolean ;

--- a/gistDeprecated.ttl
+++ b/gistDeprecated.ttl
@@ -41,6 +41,24 @@ gist:CoherentUnit
 		;
 	.
 
+gist:CountingUnit
+	a owl:Class ;
+	owl:deprecated "true"^^xsd:boolean ;
+	owl:equivalentClass [
+		a owl:Class ;
+		owl:intersectionOf (
+			gist:UnitOfMeasure
+			[
+				a owl:Restriction ;
+				owl:onProperty gist:hasStandardUnit ;
+				owl:hasValue gist:_each ;
+			]
+		) ;
+	] ;
+	skos:definition "A unit of counting, especially ?each?, but also units such as dozen."^^xsd:string ;
+	skos:prefLabel "Counting Unit"^^xsd:string ;
+	.
+
 gist:Extent
 	a owl:Class ;
 	owl:deprecated "true"^^xsd:boolean ;
@@ -75,6 +93,24 @@ gist:Group
 	] ;
 	skos:definition "A collection of People. The group may or may not be an Organization.  Many organizations consist of groups of people, but that is not a defining characteristic."^^xsd:string ;
 	skos:prefLabel "Group"^^xsd:string ;
+	.
+
+gist:MolarQuantity
+	a owl:Class ;
+	owl:deprecated "true"^^xsd:boolean ;
+	owl:equivalentClass [
+		a owl:Class ;
+		owl:intersectionOf (
+			gist:Magnitude
+			[
+				a owl:Restriction ;
+				owl:onProperty gist:hasUnitOfMeasure ;
+				owl:someValuesFrom gist:MoleUnit ;
+			]
+		) ;
+	] ;
+	skos:definition "Amount of a substance, as counted molecules."^^xsd:string ;
+	skos:prefLabel "Molar Quantity"^^xsd:string ;
 	.
 
 gist:Project

--- a/gistDeprecated.ttl
+++ b/gistDeprecated.ttl
@@ -41,6 +41,24 @@ gist:CoherentUnit
 		;
 	.
 
+gist:Extent
+	a owl:Class ;
+	owl:deprecated "true"^^xsd:boolean ;
+	owl:equivalentClass [
+		a owl:Class ;
+		owl:intersectionOf (
+			gist:Magnitude
+			[
+				a owl:Restriction ;
+				owl:onProperty gist:hasUnitOfMeasure ;
+				owl:someValuesFrom gist:DistanceUnit ;
+			]
+		) ;
+	] ;
+	skos:definition "A measure of distance, which could be distances over the Earth, and could also be height, width, length, depth, girth, etc."^^xsd:string ;
+	skos:prefLabel "Extent"^^xsd:string ;
+	.
+
 gist:Group
 	a owl:Class ;
 	owl:deprecated "true"^^xsd:boolean ;


### PR DESCRIPTION
Made a bunch of changes to simplify and clean up things as described in #782 .   Main changes are:
- UnitOfMeasure is now  a subclass of Magnitude
- No more product or ratio or simple units

This is ready for a preliminary review to get early feedback and catch any mistakes.

STILL TO DO:
- release notes
- examples

### Details 
- StandardUnit 
  - Renamed CoherentUnit to StandardUnit (Coherent Unit is an altLabel)
  - Defined StandardUnit to be equivalent to a UnitOfMeasure that
    - has conversion=1
    - has itself as a standard unit
  - Added a scopeNote indicating that this captures the idea of dimension
  - New standard units
    - Add square meter as the standard AreaUnit
    - Add cubic meter as the standard  VolumeUnit .

- UnitOfMeasure 
  - Defined UnitOfMeasure to be equivalent to a Magnitude that:
     - has numericValue =1 (it's not called 'unit' for nothing)
     - has itself at its unit of measure
     - has conversion=1
     - has a standard unit
  - Removed UnitOfMeasure from disjoints where incorrect or redundant
  - Moved an annotation about units from Magnitude to a better home: UnitOfMeasure
  - Removed and deprecated SimpleUnitOfMeasure
  - Removed redundant typing of BaseUnits, can be inferred from enumeration.
  - Properties
    - Made hasStandardUnit functional
    - Removed and deprecated hasBaseUnit. Use hasStandardUnit instead
  
- Removed product and ratio units and magnitudes
  - Removed: ProductUnit, CoherentProductUnit, ProductMagnitude
  - Removed: RatioUnit, CoherentRatioUnit, RatioMagnitude
  - Removed uses and mentions of product and ratio unit and magnitude classes and updated definitions and annotations accordingly.
  - Percentage was redefined because it had been a subclass of RatioMagnitude which was defined in terms of RationUnit. The old definitions were inserted as blank nodes to retain same formal meaning.

- Aspect
  - Made Aspect not a subclass of Category.  Aspects such as like length, or inner diameter or cycle time do not exist for the purpose of categorizing things.  
  - Made Aspect a subclass of SchemaMetaData. An aspect is a representation of a property connecting two things. It has roughly the same meaning as an OWL property.

- Magnitude 
  - Fixed erroneous definition of Magnitude
  - Added examples for Magnitude
  - Renamed Extent to Distance for naming consistency.
  - Renamed MolarQuantity to MoleQuantity for naming consistency.
  - Renamed CountingUnit to CountUnit for naming consistency.
  - Added scopeNote to hasPrecision to say the precision of a Magnitude must have the same StandardUnit as the Magnitude.
