### PR TITLE
Changes to pre commit hook. Fixes #794

### DIFF
--- a/docs/Contributing.md
+++ b/docs/Contributing.md
@@ -53,12 +53,19 @@ Submitting an Issue
 
 - External contributors should not specify assignees, projects, or milestones. These are assigned during the internal review process.
 
-Implementation
+Contributing to gist
 -----
+
+After cloning the gist repository, run this script `./tools/setup.sh`.
 
 ### Pre-commit Hook
 
-- The `./tools` directory contains a pre-commit hook that you should copy into `./git/hooks`. This ensures that the serializer is run before each commit, converting files into a standard Turtle format in order to prevent noise in the diffs. As the comments in the file indicate, you should use the version of `rdf-toolkit.jar` in this directory, rather than another version that you may have on your local drive.
+The `./tools` directory contains a pre-commit hook that you should copy into `./git/hooks`. The setup.sh script mentioned above will do this for you.
+
+The pre-commit hook does a several things when you do a `git commit`:
+- Prevent commits to the following branchs: develop, main, and master.
+- Run the serializer before each commit. This converts files into a standard Turtle format in order to prevent noise in the diffs. As the comments in the file indicate, you should use the version of `rdf-toolkit.jar` in this directory, rather than another version that you may have on your local drive.
+- Run a `sed` command to remove `skos` stubs that Protege may add to your files.
 
 ### Working Branch
 

--- a/docs/release_notes/pr795.md
+++ b/docs/release_notes/pr795.md
@@ -1,0 +1,16 @@
+### Patch Updates
+
+Issue [#794](https://github.com/semanticarts/gist/issues/794).
+
+- Fix the serialize pre-commit hook
+  - Make sure the script starts in the root directory of the repository
+  - Correct the path to serializer
+  - Add file to the commit after the sed command
+  - Preserve file permissions during processing steps
+- Add new "root" pre-commit hook
+  - Prevent commits to these branches: develop, main, master
+  - Then run the serializer pre-commit hook
+- Add a setup.sh file to install the pre-commit hook
+- Update the documentation to reflect these changes
+
+

--- a/tools/pre-commit
+++ b/tools/pre-commit
@@ -12,8 +12,21 @@ then
 fi
 
 # Get absolute path to this script
-SCRIPT=$(readlink -f "$0")
-SCRIPTPATH=$(dirname "$SCRIPT")
+# SCRIPT=$(readlink -f "$0")
+# SCRIPTPATH=$(dirname "$SCRIPT")
+
+# Get root directory of this git repository
+base_dir=$(git rev-parse --show-toplevel)
 
 # Run the serializer
-$SCRIPTPATH/../../tools/serializer/pre-commit
+set -x
+"$base_dir/tools/serializer/pre-commit"
+rc=$?
+set +x
+
+# echo "RESULT == ${rc}"
+if [ ! ${rc} -eq 0 ] ; then
+  return 1
+fi
+
+return 0

--- a/tools/pre-commit
+++ b/tools/pre-commit
@@ -1,0 +1,19 @@
+#!/usr/bin/env sh
+
+# this is expected to be in the .git/hooks directory of the project
+
+# Stops accidental commits to branches master, main, or develop.
+BRANCH=`git rev-parse --abbrev-ref HEAD`
+
+if { [ "$BRANCH" = "develop" ] || [ "$BRANCH" = "master" ] || [ "$BRANCH" = "main" ]; }
+then
+  >&2 echo "You are on branch $BRANCH. You should not commit to this branch directly!"
+  exit 1
+fi
+
+# Get absolute path to this script
+SCRIPT=$(readlink -f "$0")
+SCRIPTPATH=$(dirname "$SCRIPT")
+
+# Run the serializer
+$SCRIPTPATH/../../tools/serializer/pre-commit

--- a/tools/pre-commit
+++ b/tools/pre-commit
@@ -1,6 +1,6 @@
 #!/usr/bin/env sh
 
-# this is expected to be in the .git/hooks directory of the project
+# this is expected to be copied into the .git/hooks directory of the project
 
 # Stops accidental commits to branches master, main, or develop.
 BRANCH=`git rev-parse --abbrev-ref HEAD`

--- a/tools/serializer/pre-commit
+++ b/tools/serializer/pre-commit
@@ -26,7 +26,7 @@ function log_error() {
   log "ERROR: $@"
 }
 
-log "This is the pre-commit hook."
+log "This is the serializer pre-commit hook."
 
 java_exe=""
 base_dir=""
@@ -85,37 +85,36 @@ function findJava() {
 
 function findSerializerJar() {
 
-  # DO NOT MODIFY! Only the version of rdf-toolkit.jar found in ${PWD}/tools/serializer should be used. Mixing versions may create bogus diffs.
-  RDF_TOOLKIT_JAR="$PWD/tools/serializer/rdf-toolkit.jar"
+  # DO NOT MODIFY! Only the version of rdf-toolkit.jar found in ${base_dir}/tools/serializer should be used. Mixing versions may create bogus diffs.
+  RDF_TOOLKIT_JAR="$base_dir/tools/serializer/rdf-toolkit.jar"
 
   if [ -f "${RDF_TOOLKIT_JAR}" ] ; then
   	log "Found rdf-toolkit: ${RDF_TOOLKIT_JAR}"
   	return 0
   fi
 
-  log_error "Could not find rdf-toolkit.jar in ${PWD}/tools/serializer. Please retrieve the file from the git repository. ONLY this version of the file should be used in order to prevent bogus diffs caused by mixing versions."
+  log_error "Could not find $RDF_TOOLKIT_JAR. Please retrieve the file from the git repository. ONLY this version of the file should be used in order to prevent bogus diffs caused by mixing versions."
 
   return 1
 }
 
-# function findBaseDir() {
+function findBaseDir() {
+  #
+  # For now, we just take the top level directory of the current git repository as the base dir
+  #
+  base_dir=$(git rev-parse --show-toplevel)
 
-#   #
-#   # For now, we just take the top level directory of the current git repository as the base dir
-#   #
-#   base_dir=$(git rev-parse --show-toplevel)
+  if [ "${base_dir}" == "" ] ; then
+    log_error "Could not find base directory"
+    return 1
+  fi
+  if [ ! -d "${base_dir}" ] ; then
+    log_error "Could not find base directory"
+    return 1
+  fi
 
-#   if [ "${base_dir}" == "" ] ; then
-#     log_error "Could not find base directory"
-#     return 1
-#   fi
-#   if [ ! -d "${base_dir}" ] ; then
-#     log_error "Could not find base directory"
-#     return 1
-#   fi
-
-#   return 0
-# }
+  return 0
+}
 
 function showFilesThatAreInCommit() {
 
@@ -125,7 +124,12 @@ function showFilesThatAreInCommit() {
 function serialize() {
 
   local file="$1"
-  if [ -f "$file" ] ; then
+  if [ ! -f "$file" ] ; then
+    log_error "Could not find file: $file"
+    return 1
+  fi
+
+#  if [ -f "$file" ] ; then
     local extension="${file##*.}"
     log "File extension is $extension"
     if [ -d "$TEMP" ] ; then
@@ -210,9 +214,9 @@ __log_config__
       log_error "sesame-serializer ended with error code ${rc}"
     fi
     return ${rc}
-  else
-    return 0
-  fi
+#  else
+#    return 0
+#  fi
 
 }
 
@@ -240,10 +244,10 @@ function remove_skos_decls () {
 }
 
 function main() {
+  findBaseDir || return 1
+  findJava || return 2
+  findSerializerJar || return 3
 
-	findJava || return 1
-	findSerializerJar || return 2
-#	findBaseDir || return 3
   serialize_all
   remove_skos_decls
 }

--- a/tools/serializer/pre-commit
+++ b/tools/serializer/pre-commit
@@ -129,7 +129,6 @@ function serialize() {
     return 1
   fi
 
-#  if [ -f "$file" ] ; then
     local extension="${file##*.}"
     log "File extension is $extension"
     if [ -d "$TEMP" ] ; then
@@ -207,6 +206,8 @@ __log_config__
 
     if [ ${rc} -eq 0 ] ; then
       log "Re-adding potentially re-serialized file to git staging area: ${file}"
+      permissions=$(stat -c "%a" "${file}")
+      chmod $permissions "${file}X"
       rm  "${file}"
       mv  "${file}X" "${file}"
       git add --update "${file}"
@@ -214,10 +215,6 @@ __log_config__
       log_error "sesame-serializer ended with error code ${rc}"
     fi
     return ${rc}
-#  else
-#    return 0
-#  fi
-
 }
 
 function serialize_all() {
@@ -245,11 +242,13 @@ function remove_skos_decls () {
 
 function main() {
   findBaseDir || return 1
+  cd $base_dir
+
   findJava || return 2
   findSerializerJar || return 3
 
-  serialize_all
-  remove_skos_decls
+  serialize_all || return 4
+  remove_skos_decls || return 5
 }
 
 main $*

--- a/tools/serializer/pre-commit
+++ b/tools/serializer/pre-commit
@@ -233,8 +233,11 @@ function serialize_all() {
 
 function remove_skos_decls () {
   for fileToBeCommitted in $(git diff --cached --name-only) ; do
+    permissions=$(stat -c "%a" "${fileToBeCommitted}")
     sed -e '/^skos/,+3d' "$fileToBeCommitted" > tmp$$
     mv tmp$$ "$fileToBeCommitted"
+    chmod $permissions "${fileToBeCommitted}"
+    git add --update "${fileToBeCommitted}"
   done
 
   return 0

--- a/tools/setup.sh
+++ b/tools/setup.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env sh
+
+# This short script is provided to do any configuration needed after cloning the gist git repository.
+# Currently, this is very minimal:
+# - install a git pre-commit hook to enforce certain expectations prior to making a commit
+
+# Get root directory of this git repository
+base_dir=$(git rev-parse --show-toplevel)
+
+# print out commands so user can see what is being done
+set -x
+
+# copy pre-commit to the git hooks directory
+cp "${base_dir}/tools/pre-commit" "${base_dir}/.git/hooks/"
+


### PR DESCRIPTION
Fixes #794

- Fix serialize pre-commit hook
  - Make sure the script starts in the root directory of the repository
  - Correct the path to serializer
  - Add file to the commit after the sed command
  - Preserve file permissions during processing steps
  - Return a failure code (non zero return value) when the serializer fails
- Add new "root" pre-commit hook
  - Prevent commits to these branches: develop, main, master
  - Then run the serializer pre-commit hook
- Add a setup.sh file to install the pre-commit hook
- Update the documentation a little

Everyone should run the script `./tools/setup.sh` after pulling in these changes.