### PR TITLE
Update skos:definition of gist:nonConformingLabel. Fixes #753.

### DIFF
--- a/gistValidationAnnotations.ttl
+++ b/gistValidationAnnotations.ttl
@@ -27,7 +27,7 @@ gist:nonConformingLabel
 		) ;
 	] ;
 	rdfs:range xsd:boolean ;
-	skos:definition "The annotated ontology entity is excluded from label validation rules."^^xsd:string ;
+	skos:definition "Indicates that the annotated term is not required to conform to validation rules for formatting labels."^^xsd:string ;
 	skos:prefLabel "non-conforming label"^^xsd:string ;
 	.
 

--- a/gistValidationAnnotations.ttl
+++ b/gistValidationAnnotations.ttl
@@ -27,7 +27,7 @@ gist:nonConformingLabel
 		) ;
 	] ;
 	rdfs:range xsd:boolean ;
-	skos:definition "Indicates that the annotated term is not required to conform to validation rules for formatting labels."^^xsd:string ;
+	skos:definition "Indicates that the annotated ontology term is exempt from label validation rules."^^xsd:string ;
 	skos:prefLabel "non-conforming label"^^xsd:string ;
 	.
 

--- a/gistValidationAnnotations.ttl
+++ b/gistValidationAnnotations.ttl
@@ -27,7 +27,7 @@ gist:nonConformingLabel
 		) ;
 	] ;
 	rdfs:range xsd:boolean ;
-	skos:definition "Indicates that the annotated ontology term is exempt from label validation rules."^^xsd:string ;
+	skos:definition "Indicates that the annotated ontology entity is exempt from label validation rules."^^xsd:string ;
 	skos:prefLabel "non-conforming label"^^xsd:string ;
 	.
 


### PR DESCRIPTION
Fixes #753.

Note that there is no release note for this PR, as the change is too trivial to document.