### PR TITLE
Update message in bundle.yaml. Fixes #754

### DIFF
--- a/bundle.yaml
+++ b/bundle.yaml
@@ -105,7 +105,7 @@ actions:
   includes:
     - "*.ttl"
 - action: "sparql"
-  message: "Generating rdfs:label for backward compatibility."
+  message: "Generating rdfs:label and rdfs:comment for backward compatibility."
   source: "{output}"
   target: "{output}/rdfsAnnotations.ttl"
   format: "turtle"
@@ -115,6 +115,7 @@ actions:
     prefix gist: <https://ontologies.semanticarts.com/gist/>
     prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>
     prefix skos: <http://www.w3.org/2004/02/skos/core#>
+
     CONSTRUCT {{
       ?entity rdfs:label ?label ;
               rdfs:comment ?comment .


### PR DESCRIPTION
Fixes #754.

No release note - too trivial to document.

Only one change was made, to the message value on the RDFS annotation action. Other changes were too trivial to bother with, and I don't actually understand my notes.