### PR TITLE
Remove inverses. Fixes #506.

### DIFF
--- a/docs/release_notes/pr813.md
+++ b/docs/release_notes/pr813.md
@@ -1,5 +1,29 @@
 ### Major Updates
 
-- Removed all inverse properties. Issue [#506](https://github.com/semanticarts/gist/issues/506).
+- Removed all inverse properties. Issue [#506](https://github.com/semanticarts/gist/issues/506)
+
   - For each pair of inverses, the property deemed clearest, simplest, and/or most useful was retained.
   - Relevant axioms changed to include only properties that were kept in gist.
+  - Breakdown:
+  
+      | Properties retained in gist | Inverse properties removed from gist|
+      | ----------- | ----------- | 
+      `containsGeographically` | `isGeographicallyContainedIn`
+      `hasDirectPart` | `isDirectPartOf`
+      `hasDirectSubTask` | `isDirectSubTaskOf`
+      `hasDirectSuperCategory` | `hasDirectSubCategory`
+      `hasMember` | `isMemberOf`
+      `hasNavigationalParent` | `hasNavigationalChild`
+      `hasPart` | `isPartOf`
+      `hasSubTask` | `isSubTaskOf`
+      `hasSuperCategory` | `hasSubCategory`
+      `isAbout` | `isDescribedIn`
+      `isAffectedBy` | `affects`
+      `isBasedOn` | `isBasisFor`
+      `isGovernedBy` | `governs`
+      `isIdentifiedBy` | `identifies`
+      `isRecognizedBy` | `recognizes`
+      `occupiesGeographically` | `isGeographicallyOccupiedBy`
+      `occupiesGeographicallyPermanently` | `isGeographicallyPermanentlyOccupiedBy`
+      `precedes` | `follows`
+      `precedesDirectly` | `followsDirectly`

--- a/docs/release_notes/pr813.md
+++ b/docs/release_notes/pr813.md
@@ -8,7 +8,6 @@
   
       | Properties retained in gist | Inverse properties removed from gist|
       | ----------- | ----------- | 
-      `containsGeographically` | `isGeographicallyContainedIn`
       `hasDirectPart` | `isDirectPartOf`
       `hasDirectSubTask` | `isDirectSubTaskOf`
       `hasDirectSuperCategory` | `hasDirectSubCategory`
@@ -20,6 +19,7 @@
       `isAbout` | `isDescribedIn`
       `isAffectedBy` | `affects`
       `isBasedOn` | `isBasisFor`
+      `isGeographicallyContainedIn` | `containsGeographically`
       `isGovernedBy` | `governs`
       `isIdentifiedBy` | `identifies`
       `isRecognizedBy` | `recognizes`

--- a/docs/release_notes/pr813.md
+++ b/docs/release_notes/pr813.md
@@ -1,0 +1,6 @@
+### Major Updates
+
+- Removed all inverse properties. Issue [#506](https://github.com/semanticarts/gist/issues/506).
+  - Removed all inverse properties, keeping the more useful property directions in gist.
+  - Relevant axioms changed to include only properties that were kept in gist.
+  - Changed `hasSuperCategory` to `isSubCategoryOf`, `hasUniqueSuperCategory` to `isUniqueSubCategoryOf`, and `hasDirectSuperCategory` to `isDirectSubCategoryOf`.

--- a/docs/release_notes/pr813.md
+++ b/docs/release_notes/pr813.md
@@ -1,6 +1,5 @@
 ### Major Updates
 
 - Removed all inverse properties. Issue [#506](https://github.com/semanticarts/gist/issues/506).
-  - Removed all inverse properties, keeping the more useful property directions in gist.
+  - For each pair of inverses, the property deemed clearest, simplest, and/or most useful was retained.
   - Relevant axioms changed to include only properties that were kept in gist.
-  - Changed `hasSuperCategory` to `isSubCategoryOf`, `hasUniqueSuperCategory` to `isUniqueSubCategoryOf`, and `hasDirectSuperCategory` to `isDirectSubCategoryOf`.

--- a/gistCore.ttl
+++ b/gistCore.ttl
@@ -1723,7 +1723,9 @@ gist:OrderedCollection
 				owl:unionOf (
 					[
 						a owl:Restriction ;
-						owl:onProperty gist:hasFirstMember ;
+						owl:onProperty [
+							owl:inverseOf gist:isFirstMemberOf ;
+						] ;
 						owl:someValuesFrom owl:Thing ;
 					]
 					[
@@ -3161,21 +3163,6 @@ gist:hasDenominator
 	skos:prefLabel "has denominator"^^xsd:string ;
 	.
 
-gist:hasFirstMember
-	a
-		owl:ObjectProperty ,
-		owl:InverseFunctionalProperty
-		;
-	rdfs:subPropertyOf [
-		owl:inverseOf gist:isMemberOf ;
-	] ;
-	rdfs:domain gist:OrderedCollection ;
-	rdfs:range gist:OrderedMember ;
-	skos:definition "Relates an ordered collection to its first member."^^xsd:string ;
-	skos:prefLabel "has first member"^^xsd:string ;
-	skos:scopeNote "Given the Open World Assumption, the absence of a predecessor does not entail that an ordered member is the first member of an ordered collection. This property is used to explicitly indicate the first member. Since ordered collections may not be strictly ordered, there can be more than one first member."^^xsd:string ;
-	.
-
 gist:hasGiver
 	a owl:ObjectProperty ;
 	rdfs:subPropertyOf gist:hasParticipant ;
@@ -3405,6 +3392,19 @@ gist:isExpressedIn
 	a owl:ObjectProperty ;
 	skos:definition "The language something was expressed in"^^xsd:string ;
 	skos:prefLabel "is expressed in"^^xsd:string ;
+	.
+
+gist:isFirstMemberOf
+	a
+		owl:ObjectProperty ,
+		owl:FunctionalProperty
+		;
+	rdfs:subPropertyOf gist:isMemberOf ;
+	rdfs:domain gist:OrderedMember ;
+	rdfs:range gist:OrderedCollection ;
+	skos:definition "Relates the first member of an ordered collection to that collection."^^xsd:string ;
+	skos:prefLabel "is first member of"^^xsd:string ;
+	skos:scopeNote "Given the Open World Assumption, the absence of a predecessor does not entail that an ordered member is the first member of an ordered collection. This property is used to explicitly indicate the first member. Since ordered collections may not be strictly ordered, there can be more than one first member."^^xsd:string ;
 	.
 
 gist:isGeographicallyContainedIn

--- a/gistCore.ttl
+++ b/gistCore.ttl
@@ -2352,7 +2352,9 @@ gist:Taxonomy
 							owl:unionOf (
 								[
 									a owl:Restriction ;
-									owl:onProperty [owl:inverseOf gist:isSubCategoryOf] ;
+									owl:onProperty [
+										owl:inverseOf gist:isSubCategoryOf ;
+									] ;
 									owl:someValuesFrom gist:Category ;
 								]
 								[
@@ -3159,14 +3161,6 @@ gist:hasDenominator
 	skos:prefLabel "has denominator"^^xsd:string ;
 	.
 
-gist:isDirectSubCategoryOf
-	a owl:ObjectProperty ;
-	rdfs:subPropertyOf gist:isSubCategoryOf ;
-	skos:definition "The subject category is a subcategory of the object category. This property defines the direct links in a category hierarchy; no intermediate categories can exist between the direct links."^^xsd:string ;
-	skos:prefLabel "is direct subcategory of"^^xsd:string ;
-	skos:scopeNote "Unlike its superproperty gist:isSubCategoryOf, this property is not transitive. It is essentially the same as the non-transitive skos:broader, using gist:Category rather than skos:Concept."^^xsd:string ;
-	.
-
 gist:hasFirstMember
 	a
 		owl:ObjectProperty ,
@@ -3301,16 +3295,6 @@ gist:hasStandardUnit
 	skos:prefLabel "has standard unit"^^xsd:string ;
 	.
 
-gist:isSubCategoryOf
-	a
-		owl:ObjectProperty ,
-		owl:TransitiveProperty
-		;
-	skos:definition "The subject category is included by, or narrower than, the object category. Everything categorized by the subcategory can be inferred to be categorized by the supercategory."^^xsd:string ;
-	skos:prefLabel "is subcategory of"^^xsd:string ;
-	skos:scopeNote "This is essentially the same as skos:broaderTransitive, using gist:Category instead of skos:Concept."^^xsd:string ;
-	.
-
 gist:hasUniqueNavigationalParent
 	a
 		owl:ObjectProperty ,
@@ -3319,16 +3303,6 @@ gist:hasUniqueNavigationalParent
 	rdfs:subPropertyOf gist:hasNavigationalParent ;
 	skos:definition "Relates a subject category to a unique parent category in an informal (e.g., faceted) hierarchy."^^xsd:string ;
 	skos:prefLabel "has unique navigational parent"^^xsd:string ;
-	.
-
-gist:isUniqueSubCategoryOf
-	a
-		owl:ObjectProperty ,
-		owl:FunctionalProperty
-		;
-	rdfs:subPropertyOf gist:isSubCategoryOf ;
-	skos:definition "Used for taxos that must have single parents"^^xsd:string ;
-	skos:prefLabel "is unique subcategory of"^^xsd:string ;
 	.
 
 gist:hasUnitOfMeasure
@@ -3411,6 +3385,14 @@ gist:isDirectPartOf
 		"It is safest to use this property when there is semantic directness inherent in the relationship, rather than choosing appropriate granularity. For example, a spark plug is a direct part of an engine block; there cannot be any intermediate parts.  Beware of making a directPartOf assertion and then inserting an intermediate part; this will result in making an asserted triple false even though there was no change in the world."^^xsd:string ,
 		"Use this property to directly associate a part with the whole. partOf is the transitive version."^^xsd:string
 		;
+	.
+
+gist:isDirectSubCategoryOf
+	a owl:ObjectProperty ;
+	rdfs:subPropertyOf gist:isSubCategoryOf ;
+	skos:definition "The subject category is a subcategory of the object category. This property defines the direct links in a category hierarchy; no intermediate categories can exist between the direct links."^^xsd:string ;
+	skos:prefLabel "is direct subcategory of"^^xsd:string ;
+	skos:scopeNote "Unlike its superproperty gist:isSubCategoryOf, this property is not transitive. It is essentially the same as the non-transitive skos:broader, using gist:Category rather than skos:Concept."^^xsd:string ;
 	.
 
 gist:isDirectSubTaskOf
@@ -3499,6 +3481,16 @@ gist:isRenderedOn
 	skos:prefLabel "is rendered on"^^xsd:string ;
 	.
 
+gist:isSubCategoryOf
+	a
+		owl:ObjectProperty ,
+		owl:TransitiveProperty
+		;
+	skos:definition "The subject category is included by, or narrower than, the object category. Everything categorized by the subcategory can be inferred to be categorized by the supercategory."^^xsd:string ;
+	skos:prefLabel "is subcategory of"^^xsd:string ;
+	skos:scopeNote "This is essentially the same as skos:broaderTransitive, using gist:Category instead of skos:Concept."^^xsd:string ;
+	.
+
 gist:isSubTaskOf
 	a
 		owl:ObjectProperty ,
@@ -3518,6 +3510,16 @@ gist:isUnderJurisdictionOf
 	a owl:ObjectProperty ;
 	skos:definition "Relates a law, contract, etc., to the system of law or government which has the power, right, or authority to interpret and apply it."^^xsd:string ;
 	skos:prefLabel "is under jurisdiction of"^^xsd:string ;
+	.
+
+gist:isUniqueSubCategoryOf
+	a
+		owl:ObjectProperty ,
+		owl:FunctionalProperty
+		;
+	rdfs:subPropertyOf gist:isSubCategoryOf ;
+	skos:definition "Used for taxos that must have single parents"^^xsd:string ;
+	skos:prefLabel "is unique subcategory of"^^xsd:string ;
 	.
 
 gist:latitude

--- a/gistCore.ttl
+++ b/gistCore.ttl
@@ -3453,6 +3453,7 @@ gist:isMemberOf
 	a owl:ObjectProperty ;
 	skos:definition "What group the member is in"^^xsd:string ;
 	skos:prefLabel "is member of"^^xsd:string ;
+	gist:rangeIncludes gist:Collection ;
 	.
 
 gist:isPartOf

--- a/gistCore.ttl
+++ b/gistCore.ttl
@@ -2352,12 +2352,12 @@ gist:Taxonomy
 							owl:unionOf (
 								[
 									a owl:Restriction ;
-									owl:onProperty gist:hasSubCategory ;
+									owl:onProperty [owl:inverseOf gist:isSubCategoryOf] ;
 									owl:someValuesFrom gist:Category ;
 								]
 								[
 									a owl:Restriction ;
-									owl:onProperty gist:hasSuperCategory ;
+									owl:onProperty gist:isSubCategoryOf ;
 									owl:someValuesFrom gist:Category ;
 								]
 							) ;
@@ -3159,20 +3159,12 @@ gist:hasDenominator
 	skos:prefLabel "has denominator"^^xsd:string ;
 	.
 
-gist:hasDirectSubCategory
+gist:isDirectSubCategoryOf
 	a owl:ObjectProperty ;
-	rdfs:subPropertyOf gist:hasSubCategory ;
-	skos:definition "The subject category is a supercategory of the object category. This property defines the direct links in a category hierarchy; no intermediate categories can exist between the direct links."^^xsd:string ;
-	skos:prefLabel "has direct subcategory"^^xsd:string ;
-	skos:scopeNote "Unlike its superproperty gist:hasSubCategory, this property is not transitive. It is essentially the same as the non-transitive skos:narrower, using gist:Category rather than skos:Concept."^^xsd:string ;
-	.
-
-gist:hasDirectSuperCategory
-	a owl:ObjectProperty ;
-	rdfs:subPropertyOf gist:hasSuperCategory ;
+	rdfs:subPropertyOf gist:isSubCategoryOf ;
 	skos:definition "The subject category is a subcategory of the object category. This property defines the direct links in a category hierarchy; no intermediate categories can exist between the direct links."^^xsd:string ;
-	skos:prefLabel "has direct supercategory"^^xsd:string ;
-	skos:scopeNote "Unlike its superproperty gist:hasSuperCategory, this property is not transitive. It is essentially the same as the non-transitive skos:broader, using gist:Category rather than skos:Concept."^^xsd:string ;
+	skos:prefLabel "is direct subcategory of"^^xsd:string ;
+	skos:scopeNote "Unlike its superproperty gist:isSubCategoryOf, this property is not transitive. It is essentially the same as the non-transitive skos:broader, using gist:Category rather than skos:Concept."^^xsd:string ;
 	.
 
 gist:hasFirstMember
@@ -3309,21 +3301,13 @@ gist:hasStandardUnit
 	skos:prefLabel "has standard unit"^^xsd:string ;
 	.
 
-gist:hasSubCategory
-	a owl:ObjectProperty ;
-	owl:inverseOf gist:hasSuperCategory ;
-	skos:definition "The subject category is inclusive of, or broader than, the object category. Everything categorized by the subcategory can be inferred to be categorized by the supercategory."^^xsd:string ;
-	skos:prefLabel "has subcategory"^^xsd:string ;
-	skos:scopeNote "This is essentially the same as skos:narrowerTransitive, using gist:Category instead of skos:Concept."^^xsd:string ;
-	.
-
-gist:hasSuperCategory
+gist:isSubCategoryOf
 	a
 		owl:ObjectProperty ,
 		owl:TransitiveProperty
 		;
 	skos:definition "The subject category is included by, or narrower than, the object category. Everything categorized by the subcategory can be inferred to be categorized by the supercategory."^^xsd:string ;
-	skos:prefLabel "has supercategory"^^xsd:string ;
+	skos:prefLabel "is subcategory of"^^xsd:string ;
 	skos:scopeNote "This is essentially the same as skos:broaderTransitive, using gist:Category instead of skos:Concept."^^xsd:string ;
 	.
 
@@ -3337,14 +3321,14 @@ gist:hasUniqueNavigationalParent
 	skos:prefLabel "has unique navigational parent"^^xsd:string ;
 	.
 
-gist:hasUniqueSuperCategory
+gist:isUniqueSubCategoryOf
 	a
 		owl:ObjectProperty ,
 		owl:FunctionalProperty
 		;
-	rdfs:subPropertyOf gist:hasSuperCategory ;
+	rdfs:subPropertyOf gist:isSubCategoryOf ;
 	skos:definition "Used for taxos that must have single parents"^^xsd:string ;
-	skos:prefLabel "has unique supercategory"^^xsd:string ;
+	skos:prefLabel "is unique subcategory of"^^xsd:string ;
 	.
 
 gist:hasUnitOfMeasure

--- a/gistCore.ttl
+++ b/gistCore.ttl
@@ -67,9 +67,7 @@ gist:Agreement
 			]
 			[
 				a owl:Restriction ;
-				owl:onProperty [
-					owl:inverseOf gist:isDirectPartOf ;
-				] ;
+				owl:onProperty gist:hasDirectPart ;
 				owl:onClass gist:Obligation ;
 				owl:minQualifiedCardinality "2"^^xsd:nonNegativeInteger ;
 			]
@@ -146,9 +144,7 @@ gist:Balance
 			gist:Magnitude
 			[
 				a owl:Restriction ;
-				owl:onProperty [
-					owl:inverseOf gist:affects ;
-				] ;
+				owl:onProperty gist:isAffectedBy ;
 				owl:someValuesFrom gist:Transaction ;
 			]
 		) ;
@@ -209,9 +205,7 @@ gist:BundledCatalogItem
 			gist:CatalogItem
 			[
 				a owl:Restriction ;
-				owl:onProperty [
-					owl:inverseOf gist:isDirectPartOf ;
-				] ;
+				owl:onProperty gist:hasDirectPart ;
 				owl:someValuesFrom gist:CatalogItem ;
 			]
 		) ;
@@ -350,7 +344,7 @@ gist:Collection
 	skos:definition "A grouping of things."^^xsd:string ;
 	skos:example "A jury is a group of people, a financial ledger is a collection of transaction entries; a route is an (ordered) collection of segments."^^xsd:string ;
 	skos:prefLabel "Collection"^^xsd:string ;
-	skos:scopeNote "Individuals are placed in the collection using the gist:isMemberOf property. Collections typically are created because the members are functionally connected in some way. This definition allows a collection to have zero members."^^xsd:string ;
+	skos:scopeNote "Individuals are placed in the collection using the gist:hasMember property. Collections typically are created because the members are functionally connected in some way. This definition allows a collection to have zero members."^^xsd:string ;
 	.
 
 gist:Commitment
@@ -553,16 +547,12 @@ gist:ControlledVocabulary
 			gist:Collection
 			[
 				a owl:Restriction ;
-				owl:onProperty [
-					owl:inverseOf gist:isMemberOf ;
-				] ;
+				owl:onProperty gist:hasMember ;
 				owl:someValuesFrom gist:Category ;
 			]
 			[
 				a owl:Restriction ;
-				owl:onProperty [
-					owl:inverseOf gist:governs ;
-				] ;
+				owl:onProperty gist:isGovernedBy ;
 				owl:someValuesFrom [
 					a owl:Class ;
 					owl:unionOf (
@@ -654,9 +644,7 @@ gist:CountryGeoRegion
 			gist:GovernedGeoRegion
 			[
 				a owl:Restriction ;
-				owl:onProperty [
-					owl:inverseOf gist:governs ;
-				] ;
+				owl:onProperty gist:isGovernedBy ;
 				owl:onClass gist:CountryGovernment ;
 				owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			]
@@ -675,15 +663,15 @@ gist:CountryGovernment
 			gist:GovernmentOrganization
 			[
 				a owl:Restriction ;
-				owl:onProperty gist:governs ;
+				owl:onProperty [
+					owl:inverseOf gist:isGovernedBy ;
+				] ;
 				owl:onClass gist:CountryGeoRegion ;
 				owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			]
 			[
 				a owl:Restriction ;
-				owl:onProperty [
-					owl:inverseOf gist:governs ;
-				] ;
+				owl:onProperty gist:isGovernedBy ;
 				owl:onClass gist:GovernmentOrganization ;
 				owl:maxQualifiedCardinality "0"^^xsd:nonNegativeInteger ;
 			]
@@ -1057,9 +1045,7 @@ gist:GeoRoute
 			gist:Place
 			[
 				a owl:Restriction ;
-				owl:onProperty [
-					owl:inverseOf gist:isDirectPartOf ;
-				] ;
+				owl:onProperty gist:hasDirectPart ;
 				owl:someValuesFrom gist:GeoSegment ;
 			]
 		) ;
@@ -1100,9 +1086,7 @@ gist:GeoVolume
 		owl:intersectionOf (
 			[
 				a owl:Restriction ;
-				owl:onProperty [
-					owl:inverseOf gist:isGeographicallyContainedIn ;
-				] ;
+				owl:onProperty gist:containsGeographically ;
 				owl:someValuesFrom gist:GeoPoint ;
 			]
 			[
@@ -1131,9 +1115,7 @@ gist:GovernedGeoRegion
 			gist:GeoRegion
 			[
 				a owl:Restriction ;
-				owl:onProperty [
-					owl:inverseOf gist:governs ;
-				] ;
+				owl:onProperty gist:isGovernedBy ;
 				owl:onClass gist:GovernmentOrganization ;
 				owl:minQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			]
@@ -1265,9 +1247,7 @@ gist:IntergovernmentalOrganization
 			gist:Organization
 			[
 				a owl:Restriction ;
-				owl:onProperty [
-					owl:inverseOf gist:isMemberOf ;
-				] ;
+				owl:onProperty gist:hasMember ;
 				owl:onClass gist:GovernmentOrganization ;
 				owl:minQualifiedCardinality "2"^^xsd:nonNegativeInteger ;
 			]
@@ -1573,9 +1553,7 @@ gist:Network
 			gist:Artifact
 			[
 				a owl:Restriction ;
-				owl:onProperty [
-					owl:inverseOf gist:isMemberOf ;
-				] ;
+				owl:onProperty gist:hasMember ;
 				owl:someValuesFrom [
 					a owl:Class ;
 					owl:unionOf (
@@ -1598,7 +1576,9 @@ gist:NetworkLink
 		owl:intersectionOf (
 			[
 				a owl:Restriction ;
-				owl:onProperty gist:isMemberOf ;
+				owl:onProperty [
+					owl:inverseOf gist:hasMember ;
+				] ;
 				owl:someValuesFrom gist:Network ;
 			]
 			[
@@ -1624,7 +1604,9 @@ gist:NetworkNode
 	a owl:Class ;
 	rdfs:subClassOf [
 		a owl:Restriction ;
-		owl:onProperty gist:isMemberOf ;
+		owl:onProperty [
+			owl:inverseOf gist:hasMember ;
+		] ;
 		owl:someValuesFrom gist:Network ;
 	] ;
 	skos:definition "A node in a network."^^xsd:string ;
@@ -1675,9 +1657,7 @@ gist:Offer
 			gist:ContingentObligation
 			[
 				a owl:Restriction ;
-				owl:onProperty [
-					owl:inverseOf gist:isDirectPartOf ;
-				] ;
+				owl:onProperty gist:hasDirectPart ;
 				owl:someValuesFrom gist:CatalogItem ;
 			]
 			[
@@ -1723,25 +1703,19 @@ gist:OrderedCollection
 				owl:unionOf (
 					[
 						a owl:Restriction ;
-						owl:onProperty [
-							owl:inverseOf gist:isFirstMemberOf ;
-						] ;
+						owl:onProperty gist:hasFirstMember ;
 						owl:someValuesFrom owl:Thing ;
 					]
 					[
 						a owl:Restriction ;
-						owl:onProperty [
-							owl:inverseOf gist:isMemberOf ;
-						] ;
+						owl:onProperty gist:hasMember ;
 						owl:cardinality "0"^^xsd:nonNegativeInteger ;
 					]
 				) ;
 			]
 			[
 				a owl:Restriction ;
-				owl:onProperty [
-					owl:inverseOf gist:isMemberOf ;
-				] ;
+				owl:onProperty gist:hasMember ;
 				owl:allValuesFrom gist:OrderedMember ;
 			]
 		) ;
@@ -1780,12 +1754,16 @@ gist:OrderedMember
 			]
 			[
 				a owl:Restriction ;
-				owl:onProperty gist:isMemberOf ;
+				owl:onProperty [
+					owl:inverseOf gist:hasMember ;
+				] ;
 				owl:allValuesFrom gist:OrderedCollection ;
 			]
 			[
 				a owl:Restriction ;
-				owl:onProperty gist:isMemberOf ;
+				owl:onProperty [
+					owl:inverseOf gist:hasMember ;
+				] ;
 				owl:cardinality "1"^^xsd:nonNegativeInteger ;
 			]
 		) ;
@@ -2042,9 +2020,7 @@ gist:ProjectExecution
 			gist:TaskExecution
 			[
 				a owl:Restriction ;
-				owl:onProperty [
-					owl:inverseOf gist:isSubTaskOf ;
-				] ;
+				owl:onProperty gist:hasSubTask ;
 				owl:someValuesFrom gist:TaskExecution ;
 			]
 		) ;
@@ -2242,14 +2218,14 @@ gist:SubCountryGovernment
 			gist:GovernmentOrganization
 			[
 				a owl:Restriction ;
-				owl:onProperty gist:governs ;
+				owl:onProperty [
+					owl:inverseOf gist:isGovernedBy ;
+				] ;
 				owl:someValuesFrom gist:GeoRegion ;
 			]
 			[
 				a owl:Restriction ;
-				owl:onProperty [
-					owl:inverseOf gist:governs ;
-				] ;
+				owl:onProperty gist:isGovernedBy ;
 				owl:someValuesFrom gist:CountryGovernment ;
 			]
 		) ;
@@ -2271,9 +2247,7 @@ gist:System
 			gist:Artifact
 			[
 				a owl:Restriction ;
-				owl:onProperty [
-					owl:inverseOf gist:isDirectPartOf ;
-				] ;
+				owl:onProperty gist:hasDirectPart ;
 				owl:someValuesFrom gist:Component ;
 			]
 		) ;
@@ -2342,9 +2316,7 @@ gist:Taxonomy
 			gist:ControlledVocabulary
 			[
 				a owl:Restriction ;
-				owl:onProperty [
-					owl:inverseOf gist:isMemberOf ;
-				] ;
+				owl:onProperty gist:hasMember ;
 				owl:someValuesFrom [
 					a owl:Class ;
 					owl:intersectionOf (
@@ -2355,13 +2327,13 @@ gist:Taxonomy
 								[
 									a owl:Restriction ;
 									owl:onProperty [
-										owl:inverseOf gist:isSubCategoryOf ;
+										owl:inverseOf gist:hasSuperCategory ;
 									] ;
 									owl:someValuesFrom gist:Category ;
 								]
 								[
 									a owl:Restriction ;
-									owl:onProperty gist:isSubCategoryOf ;
+									owl:onProperty gist:hasSuperCategory ;
 									owl:someValuesFrom gist:Category ;
 								]
 							) ;
@@ -2534,16 +2506,12 @@ gist:TreatyOrganization
 			gist:IntergovernmentalOrganization
 			[
 				a owl:Restriction ;
-				owl:onProperty [
-					owl:inverseOf gist:isMemberOf ;
-				] ;
+				owl:onProperty gist:hasMember ;
 				owl:allValuesFrom gist:CountryGovernment ;
 			]
 			[
 				a owl:Restriction ;
-				owl:onProperty [
-					owl:inverseOf gist:isMemberOf ;
-				] ;
+				owl:onProperty gist:hasMember ;
 				owl:minCardinality "2"^^xsd:nonNegativeInteger ;
 			]
 		) ;
@@ -2875,12 +2843,6 @@ gist:actualStartYear
 	skos:scopeNote "Used for things where the precision of a year is sufficient. Recommended usage is to zero out the hours through microseconds to avoid spurious precision. Note that it is not valid to zero out months and days, so arbitrary values must be included."^^xsd:string ;
 	.
 
-gist:affects
-	a owl:ObjectProperty ;
-	skos:definition "The subject has, had, or will have an effect on the object."^^xsd:string ;
-	skos:prefLabel "affects"^^xsd:string ;
-	.
-
 gist:allows
 	a owl:ObjectProperty ;
 	rdfs:domain gist:Intention ;
@@ -2968,6 +2930,17 @@ gist:containedText
 	skos:prefLabel "contained text"^^xsd:string ;
 	.
 
+gist:containsGeographically
+	a
+		owl:ObjectProperty ,
+		owl:TransitiveProperty
+		;
+	rdfs:domain gist:Place ;
+	rdfs:range gist:Place ;
+	skos:definition "Relate one place to another place that is contained within the first."^^xsd:string ;
+	skos:prefLabel "contains geographically"^^xsd:string ;
+	.
+
 gist:contributesTo
 	a owl:ObjectProperty ;
 	skos:definition "The parts of a system contribute to the goal/ function of the whole system"^^xsd:string ;
@@ -3023,7 +2996,7 @@ gist:domainIncludes
 	a owl:AnnotationProperty ;
 	rdfs:subPropertyOf skos:scopeNote ;
 	skos:definition "Relates a property to a class that is (one of) the type(s) the property is expected to be used on."^^xsd:string ;
-	skos:example "The domain for the property gist:uniqueText includes gist:Text."^^xsd:string ;
+	skos:example "The domain for the property gist:hasMember includes gist:Collection."^^xsd:string ;
 	skos:prefLabel "domain includes"^^xsd:string ;
 	skos:scopeNote
 		"This property is used to guide the ontology user; like all annotation properties, it does not play a role in inference."^^xsd:string ,
@@ -3077,35 +3050,6 @@ gist:goesToPlace
 	] ;
 	skos:definition "Destination"^^xsd:string ;
 	skos:prefLabel "goes to place"^^xsd:string ;
-	.
-
-gist:governs
-	a owl:ObjectProperty ;
-	rdfs:domain [
-		a owl:Class ;
-		owl:unionOf (
-			gist:Intention
-			gist:Organization
-			gist:Person
-			gist:Template
-		) ;
-	] ;
-	rdfs:range [
-		a owl:Class ;
-		owl:unionOf (
-			gist:Category
-			gist:Content
-			gist:GeoRegion
-			gist:IntellectualProperty
-			gist:Intention
-			gist:Organization
-			gist:Person
-			gist:PhysicalIdentifiableItem
-			gist:PhysicalSubstance
-		) ;
-	] ;
-	skos:definition "The subject controls or inhibits the object in some way"^^xsd:string ;
-	skos:prefLabel "governs"^^xsd:string ;
 	.
 
 gist:hasAddress
@@ -3163,6 +3107,48 @@ gist:hasDenominator
 	skos:prefLabel "has denominator"^^xsd:string ;
 	.
 
+gist:hasDirectPart
+	a owl:ObjectProperty ;
+	rdfs:subPropertyOf gist:hasPart ;
+	skos:definition "The relationship between a whole and a part where the part has independent existence."^^xsd:string ;
+	skos:prefLabel "has direct part"^^xsd:string ;
+	skos:scopeNote
+		"It is safest to use this property when there is semantic directness inherent in the relationship, rather than choosing appropriate granularity. For example, a spark plug is a direct part of an engine block; there cannot be any intermediate parts.  Beware of making a hasDirectPart assertion and then inserting an intermediate part; this will result in making an asserted triple false even though there was no change in the world."^^xsd:string ,
+		"No cascading delete."^^xsd:string ,
+		"Use this property to directly associate a part with the whole. gist:hasPart is the transitive version."^^xsd:string
+		;
+	.
+
+gist:hasDirectSubTask
+	a owl:ObjectProperty ;
+	rdfs:subPropertyOf gist:hasSubTask ;
+	rdfs:domain gist:TaskExecution ;
+	rdfs:range gist:TaskExecution ;
+	skos:definition "Immediate child task"^^xsd:string ;
+	skos:prefLabel "has direct sub task"^^xsd:string ;
+	.
+
+gist:hasDirectSuperCategory
+	a owl:ObjectProperty ;
+	rdfs:subPropertyOf gist:hasSuperCategory ;
+	skos:definition "The subject category is a subcategory of the object category. This property defines the direct links in a category hierarchy; no intermediate categories can exist between the direct links."^^xsd:string ;
+	skos:prefLabel "has direct supercategory"^^xsd:string ;
+	skos:scopeNote "Unlike its superproperty gist:hasSuperCategory, this property is not transitive. It is essentially the same as the non-transitive skos:broader, using gist:Category rather than skos:Concept."^^xsd:string ;
+	.
+
+gist:hasFirstMember
+	a
+		owl:ObjectProperty ,
+		owl:InverseFunctionalProperty
+		;
+	rdfs:subPropertyOf gist:hasMember ;
+	rdfs:domain gist:OrderedCollection ;
+	rdfs:range gist:OrderedMember ;
+	skos:definition "Relates an ordered collection to its first member."^^xsd:string ;
+	skos:prefLabel "has first member"^^xsd:string ;
+	skos:scopeNote "Given the Open World Assumption, the absence of a predecessor does not entail that an ordered member is the first member of an ordered collection. This property is used to explicitly indicate the first member. Since ordered collections may not be strictly ordered, there can be more than one first member."^^xsd:string ;
+	.
+
 gist:hasGiver
 	a owl:ObjectProperty ;
 	rdfs:subPropertyOf gist:hasParticipant ;
@@ -3188,6 +3174,13 @@ gist:hasMagnitude
 	rdfs:range gist:Magnitude ;
 	skos:definition "To have a comparable numeric value. Each magnitude has a unit."^^xsd:string ;
 	skos:prefLabel "has magnitude"^^xsd:string ;
+	.
+
+gist:hasMember
+	a owl:ObjectProperty ;
+	skos:definition "Relates a Collection to its member individuals."^^xsd:string ;
+	skos:prefLabel "has member"^^xsd:string ;
+	gist:domainIncludes gist:Collection ;
 	.
 
 gist:hasMultiplicand
@@ -3221,6 +3214,15 @@ gist:hasOffsetToUniversal
 	rdfs:range gist:Duration ;
 	skos:definition "How many hours the time zone is off GMT"^^xsd:string ;
 	skos:prefLabel "has offset to universal"^^xsd:string ;
+	.
+
+gist:hasPart
+	a
+		owl:ObjectProperty ,
+		owl:TransitiveProperty
+		;
+	skos:definition "The transitive version of gist:hasDirectPart"^^xsd:string ;
+	skos:prefLabel "has part"^^xsd:string ;
 	.
 
 gist:hasParticipant
@@ -3282,6 +3284,27 @@ gist:hasStandardUnit
 	skos:prefLabel "has standard unit"^^xsd:string ;
 	.
 
+gist:hasSubTask
+	a
+		owl:ObjectProperty ,
+		owl:TransitiveProperty
+		;
+	rdfs:domain gist:TaskExecution ;
+	rdfs:range gist:TaskExecution ;
+	skos:definition "A task that is part of a larger task. The time frame of the subtasks may overlap but may not extend beyond the time frame of the parent task. A subtask may be part of more than one parent task."^^xsd:string ;
+	skos:prefLabel "has subtask"^^xsd:string ;
+	.
+
+gist:hasSuperCategory
+	a
+		owl:ObjectProperty ,
+		owl:TransitiveProperty
+		;
+	skos:definition "The subject category is included by, or narrower than, the object category. Everything categorized by the subcategory can be inferred to be categorized by the supercategory."^^xsd:string ;
+	skos:prefLabel "has supercategory"^^xsd:string ;
+	skos:scopeNote "This is essentially the same as skos:broaderTransitive, using gist:Category instead of skos:Concept."^^xsd:string ;
+	.
+
 gist:hasUniqueNavigationalParent
 	a
 		owl:ObjectProperty ,
@@ -3290,6 +3313,16 @@ gist:hasUniqueNavigationalParent
 	rdfs:subPropertyOf gist:hasNavigationalParent ;
 	skos:definition "Relates a subject category to a unique parent category in an informal (e.g., faceted) hierarchy."^^xsd:string ;
 	skos:prefLabel "has unique navigational parent"^^xsd:string ;
+	.
+
+gist:hasUniqueSuperCategory
+	a
+		owl:ObjectProperty ,
+		owl:FunctionalProperty
+		;
+	rdfs:subPropertyOf gist:hasSuperCategory ;
+	skos:definition "Used for taxos that must have single parents"^^xsd:string ;
+	skos:prefLabel "has unique supercategory"^^xsd:string ;
 	.
 
 gist:hasUnitOfMeasure
@@ -3306,11 +3339,27 @@ gist:hasViableRange
 	skos:prefLabel "has viable range"^^xsd:string ;
 	.
 
+gist:identifies
+	a
+		owl:ObjectProperty ,
+		owl:FunctionalProperty
+		;
+	owl:inverseOf gist:isIdentifiedBy ;
+	skos:definition "The thing the identifier refers to."^^xsd:string ;
+	skos:prefLabel "identifies"^^xsd:string ;
+	.
+
 gist:isAbout
 	a owl:ObjectProperty ;
 	rdfs:domain gist:Content ;
 	skos:definition "Subject matter of a document."^^xsd:string ;
 	skos:prefLabel "is about"^^xsd:string ;
+	.
+
+gist:isAffectedBy
+	a owl:ObjectProperty ;
+	skos:definition "Where the effect came from"^^xsd:string ;
+	skos:prefLabel "is affected by"^^xsd:string ;
 	.
 
 gist:isAllocatedBy
@@ -3364,53 +3413,39 @@ gist:isConnectedTo
 	skos:prefLabel "is connected to"^^xsd:string ;
 	.
 
-gist:isDirectPartOf
-	a owl:ObjectProperty ;
-	skos:definition "The relationship between a part and a whole where the part has independent existence."^^xsd:string ;
-	skos:prefLabel "is direct part of"^^xsd:string ;
-	skos:scopeNote
-		"It is safest to use this property when there is semantic directness inherent in the relationship, rather than choosing appropriate granularity. For example, a spark plug is a direct part of an engine block; there cannot be any intermediate parts.  Beware of making a directPartOf assertion and then inserting an intermediate part; this will result in making an asserted triple false even though there was no change in the world."^^xsd:string ,
-		"Use this property to directly associate a part with the whole. partOf is the transitive version."^^xsd:string
-		;
-	.
-
-gist:isDirectSubCategoryOf
-	a owl:ObjectProperty ;
-	rdfs:subPropertyOf gist:isSubCategoryOf ;
-	skos:definition "The subject category is a subcategory of the object category. This property defines the direct links in a category hierarchy; no intermediate categories can exist between the direct links."^^xsd:string ;
-	skos:prefLabel "is direct subcategory of"^^xsd:string ;
-	skos:scopeNote "Unlike its superproperty gist:isSubCategoryOf, this property is not transitive. It is essentially the same as the non-transitive skos:broader, using gist:Category rather than skos:Concept."^^xsd:string ;
-	.
-
-gist:isDirectSubTaskOf
-	a owl:ObjectProperty ;
-	skos:definition "Immediate parent task"^^xsd:string ;
-	skos:prefLabel "is direct subtask of"^^xsd:string ;
-	.
-
 gist:isExpressedIn
 	a owl:ObjectProperty ;
 	skos:definition "The language something was expressed in"^^xsd:string ;
 	skos:prefLabel "is expressed in"^^xsd:string ;
 	.
 
-gist:isFirstMemberOf
-	a
-		owl:ObjectProperty ,
-		owl:FunctionalProperty
-		;
-	rdfs:subPropertyOf gist:isMemberOf ;
-	rdfs:domain gist:OrderedMember ;
-	rdfs:range gist:OrderedCollection ;
-	skos:definition "Relates the first member of an ordered collection to that collection."^^xsd:string ;
-	skos:prefLabel "is first member of"^^xsd:string ;
-	skos:scopeNote "Given the Open World Assumption, the absence of a predecessor does not entail that an ordered member is the first member of an ordered collection. This property is used to explicitly indicate the first member. Since ordered collections may not be strictly ordered, there can be more than one first member."^^xsd:string ;
-	.
-
-gist:isGeographicallyContainedIn
+gist:isGovernedBy
 	a owl:ObjectProperty ;
-	skos:definition "Relates one place to another place that contains the first."^^xsd:string ;
-	skos:prefLabel "is geographically contained in"^^xsd:string ;
+	rdfs:domain [
+		a owl:Class ;
+		owl:unionOf (
+			gist:Category
+			gist:Content
+			gist:GeoRegion
+			gist:IntellectualProperty
+			gist:Intention
+			gist:Organization
+			gist:Person
+			gist:PhysicalIdentifiableItem
+			gist:PhysicalSubstance
+		) ;
+	] ;
+	rdfs:range [
+		a owl:Class ;
+		owl:unionOf (
+			gist:Intention
+			gist:Organization
+			gist:Person
+			gist:Template
+		) ;
+	] ;
+	skos:definition "A reference from the thing being governed to the governor"^^xsd:string ;
+	skos:prefLabel "is governed by"^^xsd:string ;
 	.
 
 gist:isIdentifiedBy
@@ -3429,22 +3464,6 @@ gist:isMadeUpOf
 	skos:definition "Relates something to a substance that it is made up of."^^xsd:string ;
 	skos:example "The vase is made up of clay. Water is made up of hydrogen and oxygen."^^xsd:string ;
 	skos:prefLabel "is made up of"^^xsd:string ;
-	.
-
-gist:isMemberOf
-	a owl:ObjectProperty ;
-	skos:definition "What group the member is in"^^xsd:string ;
-	skos:prefLabel "is member of"^^xsd:string ;
-	gist:rangeIncludes gist:Collection ;
-	.
-
-gist:isPartOf
-	a
-		owl:ObjectProperty ,
-		owl:TransitiveProperty
-		;
-	skos:definition "The transitive version of gist:isDirectPartOf"^^xsd:string ;
-	skos:prefLabel "is part of"^^xsd:string ;
 	.
 
 gist:isRecognizedBy
@@ -3481,25 +3500,6 @@ gist:isRenderedOn
 	skos:prefLabel "is rendered on"^^xsd:string ;
 	.
 
-gist:isSubCategoryOf
-	a
-		owl:ObjectProperty ,
-		owl:TransitiveProperty
-		;
-	skos:definition "The subject category is included by, or narrower than, the object category. Everything categorized by the subcategory can be inferred to be categorized by the supercategory."^^xsd:string ;
-	skos:prefLabel "is subcategory of"^^xsd:string ;
-	skos:scopeNote "This is essentially the same as skos:broaderTransitive, using gist:Category instead of skos:Concept."^^xsd:string ;
-	.
-
-gist:isSubTaskOf
-	a
-		owl:ObjectProperty ,
-		owl:TransitiveProperty
-		;
-	skos:definition "All the upper tasks this task belongs to"^^xsd:string ;
-	skos:prefLabel "is subtask of"^^xsd:string ;
-	.
-
 gist:isTriggeredBy
 	a owl:ObjectProperty ;
 	skos:definition "General causal relation.  For obligations a property that describes what would happen to trigger the contingent obligation.  In most cases, before the Contingent becomes an Obligation, the triggered by event is a planned event (that is it hasn't happened yet -- if it had happened the contingency would no longer be contingent.  In most cases it will be  a ContingentEvent .  Other uses include controls, processes etc"^^xsd:string ;
@@ -3510,16 +3510,6 @@ gist:isUnderJurisdictionOf
 	a owl:ObjectProperty ;
 	skos:definition "Relates a law, contract, etc., to the system of law or government which has the power, right, or authority to interpret and apply it."^^xsd:string ;
 	skos:prefLabel "is under jurisdiction of"^^xsd:string ;
-	.
-
-gist:isUniqueSubCategoryOf
-	a
-		owl:ObjectProperty ,
-		owl:FunctionalProperty
-		;
-	rdfs:subPropertyOf gist:isSubCategoryOf ;
-	skos:definition "Used for taxos that must have single parents"^^xsd:string ;
-	skos:prefLabel "is unique subcategory of"^^xsd:string ;
 	.
 
 gist:latitude
@@ -3611,7 +3601,7 @@ gist:occupiesGeographically
 		) ;
 	] ;
 	rdfs:range gist:Place ;
-	skos:definition "A thing occupies a region"^^xsd:string ;
+	skos:definition "A thing occupies are region"^^xsd:string ;
 	skos:prefLabel "occupies geographically"^^xsd:string ;
 	.
 

--- a/gistCore.ttl
+++ b/gistCore.ttl
@@ -1086,7 +1086,9 @@ gist:GeoVolume
 		owl:intersectionOf (
 			[
 				a owl:Restriction ;
-				owl:onProperty gist:containsGeographically ;
+				owl:onProperty [
+					owl:inverseOf gist:isGeographicallyContainedIn ;
+				] ;
 				owl:someValuesFrom gist:GeoPoint ;
 			]
 			[
@@ -2930,17 +2932,6 @@ gist:containedText
 	skos:prefLabel "contained text"^^xsd:string ;
 	.
 
-gist:containsGeographically
-	a
-		owl:ObjectProperty ,
-		owl:TransitiveProperty
-		;
-	rdfs:domain gist:Place ;
-	rdfs:range gist:Place ;
-	skos:definition "Relate one place to another place that is contained within the first."^^xsd:string ;
-	skos:prefLabel "contains geographically"^^xsd:string ;
-	.
-
 gist:contributesTo
 	a owl:ObjectProperty ;
 	skos:definition "The parts of a system contribute to the goal/ function of the whole system"^^xsd:string ;
@@ -3407,6 +3398,17 @@ gist:isExpressedIn
 	a owl:ObjectProperty ;
 	skos:definition "The language something was expressed in"^^xsd:string ;
 	skos:prefLabel "is expressed in"^^xsd:string ;
+	.
+
+gist:isGeographicallyContainedIn
+	a
+		owl:ObjectProperty ,
+		owl:TransitiveProperty
+		;
+	rdfs:domain gist:Place ;
+	rdfs:range gist:Place ;
+	skos:definition "Relates one place to another place that contains the first."^^xsd:string ;
+	skos:prefLabel "is geographically contained in"^^xsd:string ;
 	.
 
 gist:isGovernedBy

--- a/gistCore.ttl
+++ b/gistCore.ttl
@@ -3339,16 +3339,6 @@ gist:hasViableRange
 	skos:prefLabel "has viable range"^^xsd:string ;
 	.
 
-gist:identifies
-	a
-		owl:ObjectProperty ,
-		owl:FunctionalProperty
-		;
-	owl:inverseOf gist:isIdentifiedBy ;
-	skos:definition "The thing the identifier refers to."^^xsd:string ;
-	skos:prefLabel "identifies"^^xsd:string ;
-	.
-
 gist:isAbout
 	a owl:ObjectProperty ;
 	rdfs:domain gist:Content ;

--- a/gistCore.ttl
+++ b/gistCore.ttl
@@ -67,7 +67,9 @@ gist:Agreement
 			]
 			[
 				a owl:Restriction ;
-				owl:onProperty gist:hasDirectPart ;
+				owl:onProperty [
+					owl:inverseOf gist:isDirectPartOf ;
+				] ;
 				owl:onClass gist:Obligation ;
 				owl:minQualifiedCardinality "2"^^xsd:nonNegativeInteger ;
 			]
@@ -144,7 +146,9 @@ gist:Balance
 			gist:Magnitude
 			[
 				a owl:Restriction ;
-				owl:onProperty gist:isAffectedBy ;
+				owl:onProperty [
+					owl:inverseOf gist:affects ;
+				] ;
 				owl:someValuesFrom gist:Transaction ;
 			]
 		) ;
@@ -205,7 +209,9 @@ gist:BundledCatalogItem
 			gist:CatalogItem
 			[
 				a owl:Restriction ;
-				owl:onProperty gist:hasDirectPart ;
+				owl:onProperty [
+					owl:inverseOf gist:isDirectPartOf ;
+				] ;
 				owl:someValuesFrom gist:CatalogItem ;
 			]
 		) ;
@@ -344,7 +350,7 @@ gist:Collection
 	skos:definition "A grouping of things."^^xsd:string ;
 	skos:example "A jury is a group of people, a financial ledger is a collection of transaction entries; a route is an (ordered) collection of segments."^^xsd:string ;
 	skos:prefLabel "Collection"^^xsd:string ;
-	skos:scopeNote "Individuals are placed in the collection using the gist:hasMember property. Collections typically are created because the members are functionally connected in some way. This definition allows a collection to have zero members."^^xsd:string ;
+	skos:scopeNote "Individuals are placed in the collection using the gist:isMemberOf property. Collections typically are created because the members are functionally connected in some way. This definition allows a collection to have zero members."^^xsd:string ;
 	.
 
 gist:Commitment
@@ -547,12 +553,16 @@ gist:ControlledVocabulary
 			gist:Collection
 			[
 				a owl:Restriction ;
-				owl:onProperty gist:hasMember ;
+				owl:onProperty [
+					owl:inverseOf gist:isMemberOf ;
+				] ;
 				owl:someValuesFrom gist:Category ;
 			]
 			[
 				a owl:Restriction ;
-				owl:onProperty gist:isGovernedBy ;
+				owl:onProperty [
+					owl:inverseOf gist:governs ;
+				] ;
 				owl:someValuesFrom [
 					a owl:Class ;
 					owl:unionOf (
@@ -644,7 +654,9 @@ gist:CountryGeoRegion
 			gist:GovernedGeoRegion
 			[
 				a owl:Restriction ;
-				owl:onProperty gist:isGovernedBy ;
+				owl:onProperty [
+					owl:inverseOf gist:governs ;
+				] ;
 				owl:onClass gist:CountryGovernment ;
 				owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			]
@@ -669,7 +681,9 @@ gist:CountryGovernment
 			]
 			[
 				a owl:Restriction ;
-				owl:onProperty gist:isGovernedBy ;
+				owl:onProperty [
+					owl:inverseOf gist:governs ;
+				] ;
 				owl:onClass gist:GovernmentOrganization ;
 				owl:maxQualifiedCardinality "0"^^xsd:nonNegativeInteger ;
 			]
@@ -1043,7 +1057,9 @@ gist:GeoRoute
 			gist:Place
 			[
 				a owl:Restriction ;
-				owl:onProperty gist:hasDirectPart ;
+				owl:onProperty [
+					owl:inverseOf gist:isDirectPartOf ;
+				] ;
 				owl:someValuesFrom gist:GeoSegment ;
 			]
 		) ;
@@ -1084,7 +1100,9 @@ gist:GeoVolume
 		owl:intersectionOf (
 			[
 				a owl:Restriction ;
-				owl:onProperty gist:containsGeographically ;
+				owl:onProperty [
+					owl:inverseOf gist:isGeographicallyContainedIn ;
+				] ;
 				owl:someValuesFrom gist:GeoPoint ;
 			]
 			[
@@ -1113,7 +1131,9 @@ gist:GovernedGeoRegion
 			gist:GeoRegion
 			[
 				a owl:Restriction ;
-				owl:onProperty gist:isGovernedBy ;
+				owl:onProperty [
+					owl:inverseOf gist:governs ;
+				] ;
 				owl:onClass gist:GovernmentOrganization ;
 				owl:minQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			]
@@ -1245,15 +1265,17 @@ gist:IntergovernmentalOrganization
 			gist:Organization
 			[
 				a owl:Restriction ;
-				owl:onProperty gist:hasMember ;
+				owl:onProperty [
+					owl:inverseOf gist:isMemberOf ;
+				] ;
 				owl:onClass gist:GovernmentOrganization ;
 				owl:minQualifiedCardinality "2"^^xsd:nonNegativeInteger ;
 			]
 		) ;
 	] ;
-	skos:definition "An organization whose members are government organizations. This can comprise regional, municipal, state/province, or national level entities."^^xsd:string ;
-	skos:example "The United Nations, the European Union, the MTA (Metropolitan Transit Authority)"^^xsd:string ;
-	skos:prefLabel "Intergovernmental Organization"^^xsd:string ;
+	skos:definition "An organization whose members are government organizations."^^xsd:string ;
+	skos:example "The United Nations, the European Union"^^xsd:string ;
+	skos:prefLabel "Inter-Governmental Organization"^^xsd:string ;
 	.
 
 gist:Landmark
@@ -1551,7 +1573,9 @@ gist:Network
 			gist:Artifact
 			[
 				a owl:Restriction ;
-				owl:onProperty gist:hasMember ;
+				owl:onProperty [
+					owl:inverseOf gist:isMemberOf ;
+				] ;
 				owl:someValuesFrom [
 					a owl:Class ;
 					owl:unionOf (
@@ -1651,7 +1675,9 @@ gist:Offer
 			gist:ContingentObligation
 			[
 				a owl:Restriction ;
-				owl:onProperty gist:hasDirectPart ;
+				owl:onProperty [
+					owl:inverseOf gist:isDirectPartOf ;
+				] ;
 				owl:someValuesFrom gist:CatalogItem ;
 			]
 			[
@@ -1702,14 +1728,18 @@ gist:OrderedCollection
 					]
 					[
 						a owl:Restriction ;
-						owl:onProperty gist:hasMember ;
+						owl:onProperty [
+							owl:inverseOf gist:isMemberOf ;
+						] ;
 						owl:cardinality "0"^^xsd:nonNegativeInteger ;
 					]
 				) ;
 			]
 			[
 				a owl:Restriction ;
-				owl:onProperty gist:hasMember ;
+				owl:onProperty [
+					owl:inverseOf gist:isMemberOf ;
+				] ;
 				owl:allValuesFrom gist:OrderedMember ;
 			]
 		) ;
@@ -1729,7 +1759,9 @@ gist:OrderedMember
 				owl:unionOf (
 					[
 						a owl:Restriction ;
-						owl:onProperty gist:followsDirectly ;
+						owl:onProperty [
+							owl:inverseOf gist:precedesDirectly ;
+						] ;
 						owl:someValuesFrom gist:OrderedMember ;
 					]
 					[
@@ -2008,7 +2040,9 @@ gist:ProjectExecution
 			gist:TaskExecution
 			[
 				a owl:Restriction ;
-				owl:onProperty gist:hasSubTask ;
+				owl:onProperty [
+					owl:inverseOf gist:isSubTaskOf ;
+				] ;
 				owl:someValuesFrom gist:TaskExecution ;
 			]
 		) ;
@@ -2148,7 +2182,9 @@ gist:ServiceSpecification
 			gist:CatalogItem
 			[
 				a owl:Restriction ;
-				owl:onProperty gist:isBasisFor ;
+				owl:onProperty [
+					owl:inverseOf gist:isBasedOn ;
+				] ;
 				owl:someValuesFrom gist:Event ;
 			]
 		) ;
@@ -2209,7 +2245,9 @@ gist:SubCountryGovernment
 			]
 			[
 				a owl:Restriction ;
-				owl:onProperty gist:isGovernedBy ;
+				owl:onProperty [
+					owl:inverseOf gist:governs ;
+				] ;
 				owl:someValuesFrom gist:CountryGovernment ;
 			]
 		) ;
@@ -2231,7 +2269,9 @@ gist:System
 			gist:Artifact
 			[
 				a owl:Restriction ;
-				owl:onProperty gist:hasDirectPart ;
+				owl:onProperty [
+					owl:inverseOf gist:isDirectPartOf ;
+				] ;
 				owl:someValuesFrom gist:Component ;
 			]
 		) ;
@@ -2300,7 +2340,9 @@ gist:Taxonomy
 			gist:ControlledVocabulary
 			[
 				a owl:Restriction ;
-				owl:onProperty gist:hasMember ;
+				owl:onProperty [
+					owl:inverseOf gist:isMemberOf ;
+				] ;
 				owl:someValuesFrom [
 					a owl:Class ;
 					owl:intersectionOf (
@@ -2439,15 +2481,38 @@ gist:Text
 	skos:prefLabel "Text"^^xsd:string ;
 	.
 
-gist:TimeInterval
+gist:TimeZone
 	a owl:Class ;
-	skos:definition "A span of time with a known start time, end time, and duration. As long as two of the three are known, the third can be inferred."^^xsd:string ;
-	skos:example "7pm to 9pm on Jan 1, 2001; fiscal year 2023; the week starting at midnight of January 12, 2023 and lasting exactly 168 hours."^^xsd:string ;
-	skos:prefLabel "Time Interval"^^xsd:string ;
-	skos:scopeNote
-		"An ongoing state of affairs with an unknown end time in the future cannot be a time interval; e.g. the lifespan of a living person cannot be a time interval, as the end time is unknown."^^xsd:string ,
-		"This is distinct from a gist:Duration, which describes how long a time interval lasts (e.g., one hour; 3 days; 22 minutes)."^^xsd:string
-		;
+	owl:equivalentClass [
+		a owl:Class ;
+		owl:intersectionOf (
+			gist:GeoRegion
+			[
+				a owl:Restriction ;
+				owl:onProperty gist:hasOffsetToUniversal ;
+				owl:someValuesFrom gist:Duration ;
+			]
+		) ;
+	] ;
+	skos:definition "A region that observes a uniform standard time for legal, commercial, and social purposes.  A typical time zone averages 15? of longitude in width and typically observes a clock time one hour earlier than the zone immediately to the east."^^xsd:string ;
+	skos:prefLabel "Time Zone"^^xsd:string ;
+	.
+
+gist:TimeZoneStandard
+	a owl:Class ;
+	owl:equivalentClass [
+		a owl:Class ;
+		owl:intersectionOf (
+			gist:Specification
+			[
+				a owl:Restriction ;
+				owl:onProperty gist:isBasedOn ;
+				owl:someValuesFrom gist:TimeZone ;
+			]
+		) ;
+	] ;
+	skos:definition "The algorithm for getting from Greenwich Mean Time to local time, which includes the time zone offset and rules about daylight savings time."^^xsd:string ;
+	skos:prefLabel "Time Zone Standard"^^xsd:string ;
 	.
 
 gist:Transaction
@@ -2455,6 +2520,33 @@ gist:Transaction
 	rdfs:subClassOf gist:Event ;
 	skos:definition "An event which has an effect on at least one accumulator."^^xsd:string ;
 	skos:prefLabel "Transaction"^^xsd:string ;
+	.
+
+gist:TreatyOrganization
+	a owl:Class ;
+	owl:equivalentClass [
+		a owl:Class ;
+		owl:intersectionOf (
+			gist:IntergovernmentalOrganization
+			[
+				a owl:Restriction ;
+				owl:onProperty [
+					owl:inverseOf gist:isMemberOf ;
+				] ;
+				owl:allValuesFrom gist:CountryGovernment ;
+			]
+			[
+				a owl:Restriction ;
+				owl:onProperty [
+					owl:inverseOf gist:isMemberOf ;
+				] ;
+				owl:minCardinality "2"^^xsd:nonNegativeInteger ;
+			]
+		) ;
+	] ;
+	skos:definition "An organization whose members are country governments."^^xsd:string ;
+	skos:example "NATO, the Louisiana Purchase, the Treaty of Versailles"^^xsd:string ;
+	skos:prefLabel "Treaty Organization"^^xsd:string ;
 	.
 
 gist:UnitOfMeasure
@@ -2781,7 +2873,6 @@ gist:actualStartYear
 
 gist:affects
 	a owl:ObjectProperty ;
-	owl:inverseOf gist:isAffectedBy ;
 	skos:definition "The subject has, had, or will have an effect on the object."^^xsd:string ;
 	skos:prefLabel "affects"^^xsd:string ;
 	.
@@ -2808,7 +2899,7 @@ The subproperties allow the ontologist to do three things:
 
 All datetimes are of the same format: '2021-06-01T08:03:27.12324-6:00'^^xsd:dateTime. This is compatible with and a subset of ISO 8601.
 
-A time zone offset, such as -6:00, can be included as part of the datetime itself, as shown. The offset is not the same as a time zone. There are roughly a few dozen time zone offsets and around 130 named time zones.
+Time zone offset, such as -6:00 (of which there are a few dozen) is recognized in the date itself, as shown. The actual time zone standard (of which there are 131) may optionally be attached to the event or other object itself; see property gist:usesTimeZoneStandard.
 
 There will be many historical dates that do not have a time zone offset (e.g., Lincoln's birthday, as well as about 75% of all legacy systems), and in that case the offset can be omitted. 
 
@@ -2817,6 +2908,7 @@ The conventions for precision that are repeated in each property name are as fol
 	- *Date refers to a calendar date (e.g., birthdays and invoice dates) and is assumed to have precision of one day. Time zone offset is allowed.
 	- *Minute refers to clock time; e.g., a meeting will start at 9:15 with a timezone offset. Precision is assumed to have precision of one minute.
 	- *Microsecond refers to system time, and it will be as precise as the system can supply; typically at least milliseconds, sometime microseconds.
+
 """^^xsd:string ;
 	.
 
@@ -2870,18 +2962,6 @@ gist:containedText
 	rdfs:range xsd:string ;
 	skos:definition "Links to the string corresponding to Text"^^xsd:string ;
 	skos:prefLabel "contained text"^^xsd:string ;
-	.
-
-gist:containsGeographically
-	a
-		owl:ObjectProperty ,
-		owl:TransitiveProperty
-		;
-	rdfs:domain gist:Place ;
-	rdfs:range gist:Place ;
-	owl:inverseOf gist:isGeographicallyContainedIn ;
-	skos:definition "Relate one place to another place that is contained within the first."^^xsd:string ;
-	skos:prefLabel "contains geographically"^^xsd:string ;
 	.
 
 gist:contributesTo
@@ -2939,7 +3019,7 @@ gist:domainIncludes
 	a owl:AnnotationProperty ;
 	rdfs:subPropertyOf skos:scopeNote ;
 	skos:definition "Relates a property to a class that is (one of) the type(s) the property is expected to be used on."^^xsd:string ;
-	skos:example "The domain for the property gist:hasMember includes gist:Collection."^^xsd:string ;
+	skos:example "The domain for the property gist:uniqueText includes gist:Text."^^xsd:string ;
 	skos:prefLabel "domain includes"^^xsd:string ;
 	skos:scopeNote
 		"This property is used to guide the ontology user; like all annotation properties, it does not play a role in inference."^^xsd:string ,
@@ -2964,34 +3044,6 @@ gist:endDateTime
 	skos:scopeNote
 		"This is an abstraction over the various precisions of end time, and is not expected to be asserted directly. Values with different precisions can be compared since they all have the same format."^^xsd:string ,
 		"We have looked at some extreme edge cases (e.g., did this meeting end before or after the trade was posted?) and we couldn't find any use case that required special processing. Those who have such use cases can implement them (and feel free to let us know)."^^xsd:string
-		;
-	.
-
-gist:follows
-	a
-		owl:ObjectProperty ,
-		owl:TransitiveProperty
-		;
-	owl:inverseOf gist:precedes ;
-	skos:definition "A generic ordering relation indicating that the subject comes after the object."^^xsd:string ;
-	skos:prefLabel "follows"^^xsd:string ;
-	skos:scopeNote
-		"The greater-than symbol is often used to represent this relation."^^xsd:string ,
-		"This is the transitive version of gist:followsDirectly."^^xsd:string ,
-		"Typically this predicate would be used asymmetricallly and irreflexively, but the ontology does not formalize this."^^xsd:string
-		;
-	.
-
-gist:followsDirectly
-	a owl:ObjectProperty ;
-	rdfs:subPropertyOf gist:follows ;
-	owl:inverseOf gist:precedesDirectly ;
-	skos:definition "A generic ordering relation indicating that the subject comes immediately after the object."^^xsd:string ;
-	skos:prefLabel "follows directly"^^xsd:string ;
-	skos:scopeNote
-		"If two items in an ordered collection share the same position, they both directly follow the preceding element."^^xsd:string ,
-		"It is safest to use this property only when the directness has a semantic correspondence with the world. Only break a direct link by inserting an intermediate item when that change corresponds to a change in the world."^^xsd:string ,
-		"Typically this predicate would be used asymmetricallly and irreflexively, but the ontology does not formalize this."^^xsd:string
 		;
 	.
 
@@ -3048,7 +3100,6 @@ gist:governs
 			gist:PhysicalSubstance
 		) ;
 	] ;
-	owl:inverseOf gist:isGovernedBy ;
 	skos:definition "The subject controls or inhibits the object in some way"^^xsd:string ;
 	skos:prefLabel "governs"^^xsd:string ;
 	.
@@ -3108,35 +3159,12 @@ gist:hasDenominator
 	skos:prefLabel "has denominator"^^xsd:string ;
 	.
 
-gist:hasDirectPart
-	a owl:ObjectProperty ;
-	rdfs:subPropertyOf gist:hasPart ;
-	owl:inverseOf gist:isDirectPartOf ;
-	skos:definition "The relationship between a whole and a part where the part has independent existence."^^xsd:string ;
-	skos:prefLabel "has direct part"^^xsd:string ;
-	skos:scopeNote
-		"It is safest to use this property when there is semantic directness inherent in the relationship, rather than choosing appropriate granularity. For example, a spark plug is a direct part of an engine block; there cannot be any intermediate parts.  Beware of making a hasDirectPart assertion and then inserting an intermediate part; this will result in making an asserted triple false even though there was no change in the world."^^xsd:string ,
-		"No cascading delete."^^xsd:string ,
-		"Use this property to directly associate a part with the whole. gist:hasPart is the transitive version."^^xsd:string
-		;
-	.
-
 gist:hasDirectSubCategory
 	a owl:ObjectProperty ;
 	rdfs:subPropertyOf gist:hasSubCategory ;
 	skos:definition "The subject category is a supercategory of the object category. This property defines the direct links in a category hierarchy; no intermediate categories can exist between the direct links."^^xsd:string ;
 	skos:prefLabel "has direct subcategory"^^xsd:string ;
 	skos:scopeNote "Unlike its superproperty gist:hasSubCategory, this property is not transitive. It is essentially the same as the non-transitive skos:narrower, using gist:Category rather than skos:Concept."^^xsd:string ;
-	.
-
-gist:hasDirectSubTask
-	a owl:ObjectProperty ;
-	rdfs:subPropertyOf gist:hasSubTask ;
-	rdfs:domain gist:TaskExecution ;
-	rdfs:range gist:TaskExecution ;
-	owl:inverseOf gist:isDirectSubTaskOf ;
-	skos:definition "Immediate child task"^^xsd:string ;
-	skos:prefLabel "has direct sub task"^^xsd:string ;
 	.
 
 gist:hasDirectSuperCategory
@@ -3152,7 +3180,9 @@ gist:hasFirstMember
 		owl:ObjectProperty ,
 		owl:InverseFunctionalProperty
 		;
-	rdfs:subPropertyOf gist:hasMember ;
+	rdfs:subPropertyOf [
+		owl:inverseOf gist:isMemberOf ;
+	] ;
 	rdfs:domain gist:OrderedCollection ;
 	rdfs:range gist:OrderedMember ;
 	skos:definition "Relates an ordered collection to its first member."^^xsd:string ;
@@ -3187,14 +3217,6 @@ gist:hasMagnitude
 	skos:prefLabel "has magnitude"^^xsd:string ;
 	.
 
-gist:hasMember
-	a owl:ObjectProperty ;
-	owl:inverseOf gist:isMemberOf ;
-	skos:definition "Relates a Collection to its member individuals."^^xsd:string ;
-	skos:prefLabel "has member"^^xsd:string ;
-	gist:domainIncludes gist:Collection ;
-	.
-
 gist:hasMultiplicand
 	a owl:ObjectProperty ;
 	skos:definition "Relates a ProductUnit such as square mile to the second of two units multiplied together (e.g. mile)."^^xsd:string ;
@@ -3205,14 +3227,6 @@ gist:hasMultiplier
 	a owl:ObjectProperty ;
 	skos:definition "Relates a ProductUnit such as square mile to the first of two units multiplied together (e.g. mile)"^^xsd:string ;
 	skos:prefLabel "has multiplier"^^xsd:string ;
-	.
-
-gist:hasNavigationalChild
-	a owl:ObjectProperty ;
-	owl:inverseOf gist:hasNavigationalParent ;
-	skos:definition "Relates a parent category to a child category in an informal (e.g., faceted) hierarchy."^^xsd:string ;
-	skos:example "Refrigerator handles are not refrigerators, but it may be useful to represent their relationship hierarchically for a faceted UI filter."^^xsd:string ;
-	skos:prefLabel "has navigational child"^^xsd:string ;
 	.
 
 gist:hasNavigationalParent
@@ -3228,14 +3242,12 @@ gist:hasNumerator
 	skos:prefLabel "has numerator"^^xsd:string ;
 	.
 
-gist:hasPart
-	a
-		owl:ObjectProperty ,
-		owl:TransitiveProperty
-		;
-	owl:inverseOf gist:isPartOf ;
-	skos:definition "The transitive version of gist:hasDirectPart"^^xsd:string ;
-	skos:prefLabel "has part"^^xsd:string ;
+gist:hasOffsetToUniversal
+	a owl:ObjectProperty ;
+	rdfs:domain gist:TimeZone ;
+	rdfs:range gist:Duration ;
+	skos:definition "How many hours the time zone is off GMT"^^xsd:string ;
+	skos:prefLabel "has offset to universal"^^xsd:string ;
 	.
 
 gist:hasParticipant
@@ -3305,18 +3317,6 @@ gist:hasSubCategory
 	skos:scopeNote "This is essentially the same as skos:narrowerTransitive, using gist:Category instead of skos:Concept."^^xsd:string ;
 	.
 
-gist:hasSubTask
-	a
-		owl:ObjectProperty ,
-		owl:TransitiveProperty
-		;
-	rdfs:domain gist:TaskExecution ;
-	rdfs:range gist:TaskExecution ;
-	owl:inverseOf gist:isSubTaskOf ;
-	skos:definition "A task that is part of a larger task. The time frame of the subtasks may overlap but may not extend beyond the time frame of the parent task. A subtask may be part of more than one parent task."^^xsd:string ;
-	skos:prefLabel "has subtask"^^xsd:string ;
-	.
-
 gist:hasSuperCategory
 	a
 		owl:ObjectProperty ,
@@ -3361,28 +3361,11 @@ gist:hasViableRange
 	skos:prefLabel "has viable range"^^xsd:string ;
 	.
 
-gist:identifies
-	a
-		owl:ObjectProperty ,
-		owl:FunctionalProperty
-		;
-	owl:inverseOf gist:isIdentifiedBy ;
-	skos:definition "The thing the identifier refers to."^^xsd:string ;
-	skos:prefLabel "identifies"^^xsd:string ;
-	.
-
 gist:isAbout
 	a owl:ObjectProperty ;
 	rdfs:domain gist:Content ;
-	owl:inverseOf gist:isDescribedIn ;
 	skos:definition "Subject matter of a document."^^xsd:string ;
 	skos:prefLabel "is about"^^xsd:string ;
-	.
-
-gist:isAffectedBy
-	a owl:ObjectProperty ;
-	skos:definition "Where the effect came from"^^xsd:string ;
-	skos:prefLabel "is affected by"^^xsd:string ;
 	.
 
 gist:isAllocatedBy
@@ -3407,17 +3390,9 @@ gist:isAspectOf
 
 gist:isBasedOn
 	a owl:ObjectProperty ;
-	owl:inverseOf gist:isBasisFor ;
 	skos:definition "The Object is a foundation for, a starting point for, gave rise to or justifies the Subject"^^xsd:string ;
 	skos:example "A document is based on a document template. A metric computing the average income of a population is based on the metric for individual income."^^xsd:string ;
 	skos:prefLabel "is based on"^^xsd:string ;
-	.
-
-gist:isBasisFor
-	a owl:ObjectProperty ;
-	skos:definition "The Subject is a foundation for, a starting point for, gave rise to or justifies the Object"^^xsd:string ;
-	skos:example "The reason, law, rule, etc. behind an action or decision. The desire to create a community around the data-centric revolution/movement was the basis for initiating the Data-Centric Architecture Summit in 2018. The unabridged dictionary was the basis for the abridged dictionary."^^xsd:string ;
-	skos:prefLabel "is basis for"^^xsd:string ;
 	.
 
 gist:isCategorizedBy
@@ -3442,12 +3417,6 @@ gist:isConnectedTo
 		;
 	skos:definition "A non-owning, non-causal, non-subordinate (i.e., peer-to-peer) relationship."^^xsd:string ;
 	skos:prefLabel "is connected to"^^xsd:string ;
-	.
-
-gist:isDescribedIn
-	a owl:ObjectProperty ;
-	skos:definition "Document the subject matter appeared in"^^xsd:string ;
-	skos:prefLabel "is described in"^^xsd:string ;
 	.
 
 gist:isDirectPartOf
@@ -3476,26 +3445,6 @@ gist:isGeographicallyContainedIn
 	a owl:ObjectProperty ;
 	skos:definition "Relates one place to another place that contains the first."^^xsd:string ;
 	skos:prefLabel "is geographically contained in"^^xsd:string ;
-	.
-
-gist:isGeographicallyOccupiedBy
-	a owl:ObjectProperty ;
-	owl:inverseOf gist:occupiesGeographically ;
-	skos:definition "What is in the location"^^xsd:string ;
-	skos:prefLabel "is geographically occupied by"^^xsd:string ;
-	.
-
-gist:isGeographicallyPermanentlyOccupiedBy
-	a owl:ObjectProperty ;
-	owl:inverseOf gist:occupiesGeographicallyPermanently ;
-	skos:definition "What is in the fixed location"^^xsd:string ;
-	skos:prefLabel "is geographically permanently occupied by"^^xsd:string ;
-	.
-
-gist:isGovernedBy
-	a owl:ObjectProperty ;
-	skos:definition "A reference from the thing being governed to the governor"^^xsd:string ;
-	skos:prefLabel "is governed by"^^xsd:string ;
 	.
 
 gist:isIdentifiedBy
@@ -3540,7 +3489,6 @@ gist:isRecognizedBy
 			gist:Person
 		) ;
 	] ;
-	owl:inverseOf gist:recognizes ;
 	skos:definition "The entity that formally acknowledges the existence of, as the State recognizes the existence of a particular company"^^xsd:string ;
 	skos:prefLabel "is recognized by"^^xsd:string ;
 	.
@@ -3859,12 +3807,6 @@ gist:rangeIncludes
 		;
 	.
 
-gist:recognizes
-	a owl:ObjectProperty ;
-	skos:definition "Recognizes"^^xsd:string ;
-	skos:prefLabel "recognizes"^^xsd:string ;
-	.
-
 gist:requires
 	a owl:ObjectProperty ;
 	skos:definition "The subject needs the object or makes it necessary, mandatory, or compulsory."^^xsd:string ;
@@ -3947,6 +3889,14 @@ gist:unitSymbolUnicode
 	rdfs:range xsd:string ;
 	skos:definition "The standard symbol for the unit preferred for pretty printing, may use special characters.  E.g. square meter would be  m? rather than m^2."^^xsd:string ;
 	skos:prefLabel "unit symbol Unicode"^^xsd:string ;
+	.
+
+gist:usesTimeZoneStandard
+	a owl:ObjectProperty ;
+	rdfs:range gist:TimeZoneStandard ;
+	skos:definition "The time zone, including daylight savings time adjustment, of an event or other object that can have a date and time."^^xsd:string ;
+	skos:example "EST (Eastern Standard Time), PST (Pacific Daylight Time)."^^xsd:string ;
+	skos:prefLabel "uses time zone standard"^^xsd:string ;
 	.
 
 []

--- a/gistCore.ttl
+++ b/gistCore.ttl
@@ -3608,7 +3608,7 @@ gist:occupiesGeographically
 		) ;
 	] ;
 	rdfs:range gist:Place ;
-	skos:definition "A thing occupies are region"^^xsd:string ;
+	skos:definition "A thing occupies a region"^^xsd:string ;
 	skos:prefLabel "occupies geographically"^^xsd:string ;
 	.
 


### PR DESCRIPTION
Fixes #506.

This PR includes changes related to the removal of inverse properties from gist:

- All inverses removed. (Inverse working group has proposed which directions to keep in gist.)
- Relevant axioms have been tweaked to include only the properties that will remain in gist. A common change was to switch out a property restriction with its inverse property. For example:
```
a owl:Restriction ;
owl:onProperty gist:isBasisFor ;
owl:someValuesFrom gist:Event ;
```

becomes

```
a owl:Restriction ;
owl:onProperty [ owl:inverseOf gist:isBasedOn ] ;
owl:someValuesFrom gist:Event ;
```
- If the direction we are removing contained more information than its inverse, the additional information was maintained in some cases where useful. (See, e.g., `isGovernedBy`.)

**Breakdown** (updated after 5/1 working group meeting):


| Properties retained in gist | Inverse properties removed from gist |
| ----------- | ----------- | 
`hasDirectPart` | `isDirectPartOf`
`hasDirectSubTask` | `isDirectSubTaskOf`
`hasDirectSuperCategory` | `hasDirectSubCategory`
`hasMember` | `isMemberOf`
`hasNavigationalParent` | `hasNavigationalChild`
`hasPart` | `isPartOf`
`hasSubTask` | `isSubTaskOf`
`hasSuperCategory` | `hasSubCategory`
`isAbout` | `isDescribedIn`
`isAffectedBy` | `affects`
`isBasedOn` | `isBasisFor`
`isGeographicallyContainedIn` | `containsGeographically`
`isGovernedBy` | `governs`
`isIdentifiedBy` | `identifies`
`isRecognizedBy` | `recognizes`
  `occupiesGeographically` | `isGeographicallyOccupiedBy`
`occupiesGeographicallyPermanently` | `isGeographicallyPermanentlyOccupiedBy`
`precedes` | `follows`
`precedesDirectly` | `followsDirectly`


[Shared spreadsheet](https://datacentric.sharepoint.com/:x:/s/staff/EW-CJf41sMRAigswGyJ-aQ0BQeKvSfTcJCRoSM0ov4x2Cg?e=h2Kph0) with final summary and proposal history. (SA folks can access.)