### PR TITLE
Bugfix/776 contingent event. Fixes #776.

### DIFF
--- a/docs/release_notes/pr826.md
+++ b/docs/release_notes/pr826.md
@@ -1,0 +1,4 @@
+## Minor Updates
+
+- Removing dateTime restrictions from `gist:ContingentEvent`
+- Adding `skos:example` to `gist:ContingentEvent`

--- a/docs/release_notes/pr826.md
+++ b/docs/release_notes/pr826.md
@@ -1,4 +1,5 @@
 ## Minor Updates
 
-- Removing dateTime restrictions from `gist:ContingentEvent`
-- Adding `skos:example` to `gist:ContingentEvent`
+- Updated formal definition of `gist:ContingentEvent`. Issue [#776](https://github.com/semanticarts/gist/issues/776).
+  - Removed datetime restrictions from `gist:ContingentEvent`.
+  - Added a restriction on property `gist:isTriggeredBy`.

--- a/gistCore.ttl
+++ b/gistCore.ttl
@@ -481,7 +481,7 @@ gist:ContingentEvent
 	skos:example
 		"Fire insurance is contingent on a particular building burning down"^^xsd:string ,
 		"Sell 20 shares of stock in a given company when the price drops below $200/share."^^xsd:string ,
-		"The death benefit payout on a life insurance policy following the death of a very specific person."^^xsd:string
+		"The death benefit payout on a life insurance policy following the death of a specific person."^^xsd:string
 		;
 	skos:prefLabel "Contingent Event"^^xsd:string ;
 	.

--- a/gistCore.ttl
+++ b/gistCore.ttl
@@ -472,18 +472,14 @@ gist:ContingentEvent
 			]
 			[
 				a owl:Restriction ;
-				owl:onProperty gist:plannedEndDateTime ;
-				owl:someValuesFrom xsd:dateTime ;
-			]
-			[
-				a owl:Restriction ;
-				owl:onProperty gist:plannedStartDateTime ;
-				owl:someValuesFrom xsd:dateTime ;
+				owl:onProperty gist:isTriggeredBy ;
+				owl:someValuesFrom gist:Event ;
 			]
 		) ;
 	] ;
 	skos:definition "An event with a probability of happening in the future, and usually dependent upon some other event or condition."^^xsd:string ;
-	skos:prefLabel "Contingent Event"^^xsd:string ;
+	skos:example "Sell 20 shares of stock in a given company when the price drops below $200/share.";
+  skos:prefLabel "Contingent Event"^^xsd:string ;
 	.
 
 gist:ContingentObligation

--- a/gistCore.ttl
+++ b/gistCore.ttl
@@ -478,7 +478,11 @@ gist:ContingentEvent
 		) ;
 	] ;
 	skos:definition "An event with a probability of happening in the future, and usually dependent upon some other event or condition."^^xsd:string ;
-	skos:example "Sell 20 shares of stock in a given company when the price drops below $200/share."^^xsd:string ;
+	skos:example
+		"Fire insurance is contingent on a particular building burning down"^^xsd:string ,
+		"Sell 20 shares of stock in a given company when the price drops below $200/share."^^xsd:string ,
+		"The death benefit payout on a life insurance policy following the death of a very specific person."^^xsd:string
+		;
 	skos:prefLabel "Contingent Event"^^xsd:string ;
 	.
 

--- a/gistCore.ttl
+++ b/gistCore.ttl
@@ -478,8 +478,8 @@ gist:ContingentEvent
 		) ;
 	] ;
 	skos:definition "An event with a probability of happening in the future, and usually dependent upon some other event or condition."^^xsd:string ;
-	skos:example "Sell 20 shares of stock in a given company when the price drops below $200/share.";
-  skos:prefLabel "Contingent Event"^^xsd:string ;
+	skos:example "Sell 20 shares of stock in a given company when the price drops below $200/share."^^xsd:string ;
+	skos:prefLabel "Contingent Event"^^xsd:string ;
 	.
 
 gist:ContingentObligation


### PR DESCRIPTION
This PR removed dateTime restrictions from `gist:ContingentEvent` and adds a `skos:example`. 

See the issue here: https://github.com/semanticarts/gist/issues/776