### PR TITLE
Fix pre-commit error on deleted files - Fixes #832

### DIFF
--- a/docs/release_notes/pr834.md
+++ b/docs/release_notes/pr834.md
@@ -1,0 +1,2 @@
+## Patch
+Update tools/serializer/pre-commit to ignore, and not error on, files that have been deleted.

--- a/tools/serializer/pre-commit
+++ b/tools/serializer/pre-commit
@@ -116,17 +116,12 @@ function findBaseDir() {
   return 0
 }
 
-function showFilesThatAreInCommit() {
-
-  git diff --cached --name-only
-}
-
 function serialize() {
 
   local file="$1"
   if [ ! -f "$file" ] ; then
     log_error "Could not find file: $file"
-    return 1
+    return 0
   fi
 
     local extension="${file##*.}"
@@ -220,9 +215,8 @@ __log_config__
 function serialize_all() {
 
   #echo "Checking the following files:"
-  #showFilesThatAreInCommit
 
-  for fileToBeCommitted in $(git diff --cached --name-only) ; do
+  for fileToBeCommitted in $(git diff --name-only) ; do
     if ! serialize "$fileToBeCommitted" ; then
       return 1
     fi
@@ -232,7 +226,7 @@ function serialize_all() {
 }
 
 function remove_skos_decls () {
-  for fileToBeCommitted in $(git diff --cached --name-only) ; do
+  for fileToBeCommitted in $(git diff --name-only) ; do
     permissions=$(stat -c "%a" "${fileToBeCommitted}")
     sed -e '/^skos/,+3d' "$fileToBeCommitted" > tmp$$
     mv tmp$$ "$fileToBeCommitted"


### PR DESCRIPTION
Fixes #832 

I think this change will fix the problem reported by Rebecca that our pre-commit hook was failing on files that had been deleted.
