### PR TITLE
issue 733 - gist:hasSubTask and gist:hasDirectSubTask - all changes

### DIFF
--- a/docs/release_notes/issue733.md
+++ b/docs/release_notes/issue733.md
@@ -1,4 +1,3 @@
 ## Major Updates
 
-- Removed gist:hasSubTask and gist:hasDirectSubTask. In future, gist:hasPart and gist:hasDirectPart will respectively be used.
-- Restriction on gist:ProjectExecution updated to use gist:hasPart instead of gist:hasSubTask.
+- Removed `gist:hasSubTask` and `gist:hasDirectSubTask`. In future, `gist:hasPart` and `gist:hasDirectPart` will respectively be used. Updated the restriction on `gist:Project` to use `gist:hasPart` instead of `gist:hasSubTask`. Issue [#733](https://github.com/semanticarts/gist/issues/733).

--- a/docs/release_notes/issue733.md
+++ b/docs/release_notes/issue733.md
@@ -1,0 +1,4 @@
+## Major Updates
+
+- Removed gist:hasSubTask and gist:hasDirectSubTask. In future, gist:hasPart and gist:hasDirectPart will respectively be used.
+- Restriction on gist:ProjectExecution updated to use gist:hasPart instead of gist:hasSubTask.

--- a/gistCore.ttl
+++ b/gistCore.ttl
@@ -2022,7 +2022,7 @@ gist:ProjectExecution
 			gist:TaskExecution
 			[
 				a owl:Restriction ;
-				owl:onProperty gist:hasSubTask ;
+				owl:onProperty gist:hasPart ;
 				owl:someValuesFrom gist:TaskExecution ;
 			]
 		) ;
@@ -3110,15 +3110,6 @@ gist:hasDirectPart
 		;
 	.
 
-gist:hasDirectSubTask
-	a owl:ObjectProperty ;
-	rdfs:subPropertyOf gist:hasSubTask ;
-	rdfs:domain gist:TaskExecution ;
-	rdfs:range gist:TaskExecution ;
-	skos:definition "Immediate child task"^^xsd:string ;
-	skos:prefLabel "has direct sub task"^^xsd:string ;
-	.
-
 gist:hasDirectSuperCategory
 	a owl:ObjectProperty ;
 	rdfs:subPropertyOf gist:hasSuperCategory ;
@@ -3273,17 +3264,6 @@ gist:hasStandardUnit
 	rdfs:range gist:CoherentUnit ;
 	skos:definition "For a complex unit refers to a unit that has all the component parts in SI"^^xsd:string ;
 	skos:prefLabel "has standard unit"^^xsd:string ;
-	.
-
-gist:hasSubTask
-	a
-		owl:ObjectProperty ,
-		owl:TransitiveProperty
-		;
-	rdfs:domain gist:TaskExecution ;
-	rdfs:range gist:TaskExecution ;
-	skos:definition "A task that is part of a larger task. The time frame of the subtasks may overlap but may not extend beyond the time frame of the parent task. A subtask may be part of more than one parent task."^^xsd:string ;
-	skos:prefLabel "has subtask"^^xsd:string ;
 	.
 
 gist:hasSuperCategory
@@ -3896,3 +3876,4 @@ gist:usesTimeZoneStandard
 		gist:_second
 	) ;
 	.
+


### PR DESCRIPTION
Hi Rebecca,

This PR covers all changes for 733:
1) removed gist:hasSubTask and gist:hasDirectSubTask (since this is a major change coming up, removing them entirely per our deletion policy).
2) updated restriction on gist:ProjectExecution to reference gist:hasPart instead of gist:hasSubTask.
3) added release note file with change list.

Please let me know if I've missed anything. Thanks!
-Heather