### PR TITLE
Remove TreatyOrganization (accidentally left in)

### DIFF
--- a/gistCore.ttl
+++ b/gistCore.ttl
@@ -1261,9 +1261,9 @@ gist:IntergovernmentalOrganization
 			]
 		) ;
 	] ;
-	skos:definition "An organization whose members are government organizations."^^xsd:string ;
-	skos:example "The United Nations, the European Union"^^xsd:string ;
-	skos:prefLabel "Inter-Governmental Organization"^^xsd:string ;
+	skos:definition "An organization whose members are government organizations. This can comprise regional, municipal, state/province, or national level entities."^^xsd:string ;
+	skos:example "The United Nations, the European Union, the MTA (Metropolitan Transit Authority)"^^xsd:string ;
+	skos:prefLabel "Intergovernmental Organization"^^xsd:string ;
 	.
 
 gist:Landmark

--- a/gistCore.ttl
+++ b/gistCore.ttl
@@ -1140,10 +1140,7 @@ gist:GovernedGeoRegion
 gist:GovernmentOrganization
 	a owl:Class ;
 	rdfs:subClassOf gist:Organization ;
-	owl:disjointWith
-		gist:IntergovernmentalOrganization ,
-		gist:TreatyOrganization
-		;
+	owl:disjointWith gist:IntergovernmentalOrganization ;
 	skos:definition "An organization which exercises political and/or regulatory authority over a political unit, people, geo-region, etc., as well as performing certain functions for this unit or body. Differs from a corporation in that it cannot be owned."^^xsd:string ;
 	skos:example "The State of Washington Office of Financial Management; the Food and Drug Administration; the Scottish Parliament."^^xsd:string ;
 	skos:prefLabel "Government Organization"^^xsd:string ;
@@ -2530,29 +2527,6 @@ gist:Transaction
 	rdfs:subClassOf gist:Event ;
 	skos:definition "An event which has an effect on at least one accumulator."^^xsd:string ;
 	skos:prefLabel "Transaction"^^xsd:string ;
-	.
-
-gist:TreatyOrganization
-	a owl:Class ;
-	owl:equivalentClass [
-		a owl:Class ;
-		owl:intersectionOf (
-			gist:IntergovernmentalOrganization
-			[
-				a owl:Restriction ;
-				owl:onProperty gist:hasMember ;
-				owl:allValuesFrom gist:CountryGovernment ;
-			]
-			[
-				a owl:Restriction ;
-				owl:onProperty gist:hasMember ;
-				owl:minCardinality "2"^^xsd:nonNegativeInteger ;
-			]
-		) ;
-	] ;
-	skos:definition "An organization whose members are country governments."^^xsd:string ;
-	skos:example "NATO, the Louisiana Purchase, the Treaty of Versailles"^^xsd:string ;
-	skos:prefLabel "Treaty Organization"^^xsd:string ;
 	.
 
 gist:UnitOfMeasure

--- a/gistSubClassAssertions.ttl
+++ b/gistSubClassAssertions.ttl
@@ -500,10 +500,6 @@ gist:Transaction
 	rdfs:subClassOf gist:Event ;
 	.
 
-gist:TreatyOrganization
-	rdfs:subClassOf gist:IntergovernmentalOrganization ;
-	.
-
 gist:Volume
 	rdfs:subClassOf gist:ProductMagnitude ;
 	.


### PR DESCRIPTION
Peter found at the last minute that TreatyOrganization was still present in gistCore.ttl. This PR is to remove it consistent with the intention of issue #766 and pr #825 