### PR TITLE
Bundle.yaml fixes. Fixes #922.

### DIFF
--- a/bundle.yaml
+++ b/bundle.yaml
@@ -107,7 +107,7 @@ actions:
 - action: "sparql"
   message: "Generating rdfs:label and rdfs:comment for backward compatibility."
   source: "{output}"
-  target: "{output}/rdfsAnnotations.ttl"
+  target: "{output}/rdfsAnnotations{version}.ttl"
   format: "turtle"
   includes:
     - "*.ttl"

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -94,7 +94,10 @@ actions:
     from: "(.*)\\.ttl"
     to: "\\g<1>{version}.ttl"
   includes:
-    - "*.ttl"
+    - gistCore.ttl
+    - gistMediaTypes.ttl
+    - gistPrefixDeclarations.ttl
+    - gistSubClassAssertions.ttl
 - action: "definedBy"
   message: "Adding rdfs:isDefinedBy."
   source: "{output}"


### PR DESCRIPTION
Fixes #922.

Two changes:
* gistValidationAnnotations.ttl is not included in download package
* rdfsAnnotations files have versioned filenames

I've tested these on my end. Please run the bundler and test for both of these changes.