### PR TITLE
Bundle.yaml updates. Fixes #922

### DIFF
--- a/bundle.yaml
+++ b/bundle.yaml
@@ -107,7 +107,7 @@ actions:
 - action: "sparql"
   message: "Generating rdfs:label and rdfs:comment for backward compatibility."
   source: "{output}"
-  target: "{output}/gistRdfsAnnotations{version}.ttl"
+  target: "{output}/rdfsAnnotations.ttl"
   format: "turtle"
   includes:
     - "*.ttl"

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -107,7 +107,7 @@ actions:
 - action: "sparql"
   message: "Generating rdfs:label and rdfs:comment for backward compatibility."
   source: "{output}"
-  target: "{output}/rdfsAnnotations.ttl"
+  target: "{output}/rdfsAnnotations{version}.ttl"
   format: "turtle"
   includes:
     - "*.ttl"

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -107,7 +107,7 @@ actions:
 - action: "sparql"
   message: "Generating rdfs:label and rdfs:comment for backward compatibility."
   source: "{output}"
-  target: "{output}/rdfsAnnotations{version}.ttl"
+  target: "{output}/gistRdfsAnnotations{version}.ttl"
   format: "turtle"
   includes:
     - "*.ttl"

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -94,7 +94,10 @@ actions:
     from: "(.*)\\.ttl"
     to: "\\g<1>{version}.ttl"
   includes:
-    - "*.ttl"
+    - gistCore.ttl
+    - gistMediaTypes.ttl
+    - gistPrefixDeclarations.ttl
+    - gistSubClassAssertions.ttl
 - action: "definedBy"
   message: "Adding rdfs:isDefinedBy."
   source: "{output}"

--- a/docs/release_notes/issue-922-bundler
+++ b/docs/release_notes/issue-922-bundler
@@ -1,5 +1,3 @@
 ### Patch Updates
 
-- Updated `bundle.yaml`. Issue [#922](https://github.com/semanticarts/gist/issues/922). Changes:
-  - Excluded `gistValidationAnnotations` ontology from the release package
-  - Renamed `rdfsAnnotations` to `gistRdfsAnnotations` and added version number to the filenames.
+- Updated `bundle.yaml` to exclude the `gistValidationAnnotations` ontology from the release package. Issue [#922](https://github.com/semanticarts/gist/issues/922).

--- a/docs/release_notes/issue-922-bundler
+++ b/docs/release_notes/issue-922-bundler
@@ -1,0 +1,5 @@
+### Patch Updates
+
+- Updated `bundle.yaml`. Issue [#922](https://github.com/semanticarts/gist/issues/922). Changes:
+  - Excluded `gistValidationAnnotations` ontology from the release package
+  - Renamed `rdfsAnnotations` to `gistRdfsAnnotations` and add version number to the filenames.

--- a/docs/release_notes/issue-922-bundler
+++ b/docs/release_notes/issue-922-bundler
@@ -2,4 +2,4 @@
 
 - Updated `bundle.yaml`. Issue [#922](https://github.com/semanticarts/gist/issues/922). Changes:
   - Excluded `gistValidationAnnotations` ontology from the release package
-  - Renamed `rdfsAnnotations` to `gistRdfsAnnotations` and add version number to the filenames.
+  - Renamed `rdfsAnnotations` to `gistRdfsAnnotations` and added version number to the filenames.

--- a/docs/release_notes/patch-919-wrong-apostrophe
+++ b/docs/release_notes/patch-919-wrong-apostrophe
@@ -1,1 +1,3 @@
+### Patch Updates
+
 - Changed smart single quotes to straight quotes for the apostrophes in `docs/Namespace.md`. Issue [#919](https://github.com/semanticarts/gist/issues/919).


### PR DESCRIPTION
Fixes #922.

Two changes:
* gistValidationAnnotations.ttl is not included in download package
* rdfsAnnotations files have versioned filenames prefixed with "gist" - e.g., "gistRdfsAnnotations12.0.1.ttl" instead of "rdfsAnnotations.ttl".

I've tested these on my end. Please run the bundler and test for both of these changes.