### PR TITLE
Issue 820 is characterized as

### DIFF
--- a/docs/release_notes/820-isCharacterizedAs.md
+++ b/docs/release_notes/820-isCharacterizedAs.md
@@ -1,3 +1,3 @@
 ### Minor Updates
 
-- deprecated isCharacterizedAs
+- Deprecated `gist:isCharacterizedAs`. Issue [#820](https://github.com/semanticarts/gist/issues/820).

--- a/docs/release_notes/820-isCharacterizedAs.md
+++ b/docs/release_notes/820-isCharacterizedAs.md
@@ -1,0 +1,3 @@
+### Minor Updates
+
+- deprecated isCharacterizedAs

--- a/gistCore.ttl
+++ b/gistCore.ttl
@@ -920,7 +920,7 @@ gist:Event
 		owl:someValuesFrom gist:Behavior ;
 	] ;
 	skos:definition "Something that occurs over a period of time, often characterized as an activity being carried out by some person, organization, or software application or brought about by natural forces."^^xsd:string ;
-	skos:editorialNote "For next major release, remove the restriction that uses the deprecated isCharacterizedAs property. Consider adding a subclass restriction along the lines of (occursDuring some TimeInterval)"^^xsd:string ;
+	skos:editorialNote "See guidance on removing the term in the next major release at https://github.com/semanticarts/gist/issues/947#issuecomment-1679565100."^^xsd:string ;
 	skos:example "A transaction, conference, baseball game, earthquake."^^xsd:string ;
 	skos:prefLabel "Event"^^xsd:string ;
 	skos:scopeNote "An event does not necessarily have either planned or actual start or end datetimes. For example, a conference can be in the planning phase without any dates selected, but is nevertheless an (unscheduled) event. The subclasses of Event state particular restrictions on planned and actual start and end dates."^^xsd:string ;

--- a/gistCore.ttl
+++ b/gistCore.ttl
@@ -920,6 +920,7 @@ gist:Event
 		owl:someValuesFrom gist:Behavior ;
 	] ;
 	skos:definition "Something that occurs over a period of time, often characterized as an activity being carried out by some person, organization, or software application or brought about by natural forces."^^xsd:string ;
+	skos:editorialNote "For next major release, remove the restriction that uses the deprecated isCharacterizedAs property. Consider adding a subclass restriction along the lines of (occursDuring some TimeInterval)"^^xsd:string ;
 	skos:example "A transaction, conference, baseball game, earthquake."^^xsd:string ;
 	skos:prefLabel "Event"^^xsd:string ;
 	skos:scopeNote "An event does not necessarily have either planned or actual start or end datetimes. For example, a conference can be in the planning phase without any dates selected, but is nevertheless an (unscheduled) event. The subclasses of Event state particular restrictions on planned and actual start and end dates."^^xsd:string ;
@@ -3350,6 +3351,7 @@ gist:isCharacterizedAs
 	a owl:ObjectProperty ;
 	rdfs:domain gist:Event ;
 	rdfs:range gist:Behavior ;
+	owl:deprecated "true"^^xsd:boolean ;
 	skos:definition "A way to categorize a behavior."^^xsd:string ;
 	skos:prefLabel "is characterized as"^^xsd:string ;
 	.


### PR DESCRIPTION
Deprecated `isCharacterizedAs`
Updated: https://github.com/semanticarts/gist/issues/947

Fixes #820.