### PR TITLE
Issue 372 text datatype properties

### DIFF
--- a/docs/release_notes/372-text-datatype-properties.md
+++ b/docs/release_notes/372-text-datatype-properties.md
@@ -1,0 +1,8 @@
+### Minor Updates
+Issue [#372](https://github.com/semanticarts/gist/issues/372). Changes:
+  
+- Deprecated `tagText`, to be replaced by `containedText`.
+- `containedText` 
+  - Added domainIncludes `Tag` and `Text` 
+  - Removed reference to Text class in the definition
+  - Added examples 

--- a/docs/release_notes/372-text-datatype-properties.md
+++ b/docs/release_notes/372-text-datatype-properties.md
@@ -1,8 +1,7 @@
 ### Minor Updates
-Issue [#372](https://github.com/semanticarts/gist/issues/372). Changes:
-  
-- Deprecated `tagText`, to be replaced by `containedText`.
-- `containedText` 
-  - Added domainIncludes `Tag` and `Text` 
-  - Removed reference to Text class in the definition
-  - Added examples 
+ - `gist:tagText` to be replaced by `gist:containedText`Issue [#372](https://github.com/semanticarts/gist/issues/372).   
+   - Deprecated `gist:tagText`.
+   - `containedText`:
+     - Added domainIncludes `Tag` and `Text` 
+     - Removed reference to Text class in the definition
+     - Added examples 

--- a/gistCore.ttl
+++ b/gistCore.ttl
@@ -2286,15 +2286,18 @@ gist:System
 
 gist:Tag
 	a owl:Class ;
-	rdfs:subClassOf
-		gist:Category ,
-		[
-			a owl:Restriction ;
-			owl:onProperty gist:containedText ;
-			owl:someValuesFrom xsd:string ;
-		]
-		;
-	skos:definition "This is for folksonomy type terms, which can be made up on the fly by users."^^xsd:string ;
+	owl:equivalentClass [
+		a owl:Class ;
+		owl:intersectionOf (
+			gist:Category
+			[
+				a owl:Restriction ;
+				owl:onProperty gist:tagText ;
+				owl:someValuesFrom xsd:string ;
+			]
+		) ;
+	] ;
+	skos:definition "A term in a folksonomy used to categorize things. Tags can be made up on the fly by users."^^xsd:string ;
 	skos:prefLabel "Tag"^^xsd:string ;
 	.
 
@@ -2933,13 +2936,7 @@ gist:conformsTo
 
 gist:containedText
 	a owl:DatatypeProperty ;
-	rdfs:range [
-		a owl:Class ;
-		owl:unionOf (
-			xsd:string
-			xsd:anyURI
-		) ;
-	] ;
+	rdfs:range xsd:string ;
 	skos:definition "A string that is closely associated with an individual."^^xsd:string ;
 	skos:example
 		"The string associated with a tag."^^xsd:string ,
@@ -3851,12 +3848,18 @@ gist:startDateTime
 		;
 	.
 
+gist:tagText
+	a owl:DatatypeProperty ;
+	owl:deprecated "true"^^xsd:boolean ;
+	skos:definition "Used for folksonomy style categories (non controlled vocabulary)"^^xsd:string ;
+	skos:prefLabel "tag text"^^xsd:string ;
+	.
+
 gist:uniqueText
 	a
 		owl:DatatypeProperty ,
 		owl:FunctionalProperty
 		;
-	rdfs:subPropertyOf gist:containedText ;
 	rdfs:range xsd:string ;
 	skos:definition "The unique string value of some content object; i.e., there is no possibility of having more than one value."^^xsd:string ;
 	skos:example "The unique string for a vehicle identification number."^^xsd:string ;

--- a/gistCore.ttl
+++ b/gistCore.ttl
@@ -2941,8 +2941,15 @@ gist:containedText
 		) ;
 	] ;
 	skos:definition "A string that is closely associated with an individual."^^xsd:string ;
+	skos:example
+		"The string associated with a tag."^^xsd:string ,
+		"The string associated with text content."^^xsd:string
+		;
 	skos:prefLabel "contained text"^^xsd:string ;
-	gist:domainIncludes gist:Text ;
+	gist:domainIncludes
+		gist:Tag ,
+		gist:Text
+		;
 	.
 
 gist:contributesTo

--- a/gistCore.ttl
+++ b/gistCore.ttl
@@ -2286,17 +2286,14 @@ gist:System
 
 gist:Tag
 	a owl:Class ;
-	owl:equivalentClass [
-		a owl:Class ;
-		owl:intersectionOf (
-			gist:Category
-			[
-				a owl:Restriction ;
-				owl:onProperty gist:tagText ;
-				owl:someValuesFrom xsd:string ;
-			]
-		) ;
-	] ;
+	rdfs:subClassOf
+		gist:Category ,
+		[
+			a owl:Restriction ;
+			owl:onProperty gist:containedText ;
+			owl:someValuesFrom xsd:string ;
+		]
+		;
 	skos:definition "This is for folksonomy type terms, which can be made up on the fly by users."^^xsd:string ;
 	skos:prefLabel "Tag"^^xsd:string ;
 	.
@@ -3838,12 +3835,6 @@ gist:startDateTime
 		"This is an abstraction over the various precisions of start time, and is not expected to be asserted directly. Values with different precisions can be compared since they all have the same format."^^xsd:string ,
 		"We have looked at some extreme edge cases (e.g., did this meeting end before or after the trade was posted?) and we couldn't find any use case that required special processing. Those who have such use cases can implement them (and feel free to let us know)."^^xsd:string
 		;
-	.
-
-gist:tagText
-	a owl:DatatypeProperty ;
-	skos:definition "Used for folksonomy style categories (non controlled vocabulary)"^^xsd:string ;
-	skos:prefLabel "tag text"^^xsd:string ;
 	.
 
 gist:uniqueText

--- a/gistCore.ttl
+++ b/gistCore.ttl
@@ -3842,6 +3842,7 @@ gist:uniqueText
 		owl:DatatypeProperty ,
 		owl:FunctionalProperty
 		;
+	rdfs:subPropertyOf gist:containedText ;
 	rdfs:range xsd:string ;
 	skos:definition "The unique string value of some content object; i.e., there is no possibility of having more than one value."^^xsd:string ;
 	skos:example "The unique string for a vehicle identification number."^^xsd:string ;

--- a/gistCore.ttl
+++ b/gistCore.ttl
@@ -2298,6 +2298,7 @@ gist:Tag
 		) ;
 	] ;
 	skos:definition "A term in a folksonomy used to categorize things. Tags can be made up on the fly by users."^^xsd:string ;
+	skos:editorialNote "See guidance on removing tagText property in the next major release at https://github.com/semanticarts/gist/issues/947#issuecomment-1780220876."^^xsd:string ;
 	skos:prefLabel "Tag"^^xsd:string ;
 	.
 

--- a/gistCore.ttl
+++ b/gistCore.ttl
@@ -2934,8 +2934,9 @@ gist:conformsTo
 gist:containedText
 	a owl:DatatypeProperty ;
 	rdfs:range xsd:string ;
-	skos:definition "Links to the string corresponding to Text"^^xsd:string ;
+	skos:definition "A string that is closely associated with an individual."^^xsd:string ;
 	skos:prefLabel "contained text"^^xsd:string ;
+	gist:domainIncludes gist:Text ;
 	.
 
 gist:contributesTo

--- a/gistCore.ttl
+++ b/gistCore.ttl
@@ -2933,7 +2933,13 @@ gist:conformsTo
 
 gist:containedText
 	a owl:DatatypeProperty ;
-	rdfs:range xsd:string ;
+	rdfs:range [
+		a owl:Class ;
+		owl:unionOf (
+			xsd:string
+			xsd:anyURI
+		) ;
+	] ;
 	skos:definition "A string that is closely associated with an individual."^^xsd:string ;
 	skos:prefLabel "contained text"^^xsd:string ;
 	gist:domainIncludes gist:Text ;


### PR DESCRIPTION
Fixes #372 

- Deprecated `tagText`, to be replaced by `containedText`.
- `containedText` 
  - Added domainIncludes `Tag` and `Text` 
  - Removed reference to Text class in the definition
  - Added examples 
