### PR TITLE
Remove remove_skos_decls function from serializer pre-commit

### DIFF
--- a/docs/release_notes/1007-pre-commit
+++ b/docs/release_notes/1007-pre-commit
@@ -1,0 +1,3 @@
+### Patch Updates
+
+- Fixed serializer pre-commit hook permissions problem on MacOS.

--- a/tools/pre-commit
+++ b/tools/pre-commit
@@ -21,9 +21,8 @@ base_dir=$(git rev-parse --show-toplevel)
 # Run the serializer
 set -x
 
-# Ensure that the serializer pre-commit is executable
-chmod +x "${base_dir}/tools/serializer/pre-commit"
-"$base_dir/tools/serializer/pre-commit"
+"${base_dir}/.git/hooks/pre-commit-serializer"
+
 rc=$?
 set +x
 

--- a/tools/serializer/pre-commit
+++ b/tools/serializer/pre-commit
@@ -222,17 +222,6 @@ function serialize_all() {
   return 0
 }
 
-function remove_skos_decls () {
-  for fileToBeCommitted in $(git diff --cached --name-only) ; do
-    permissions=$(stat -c "%a" "${fileToBeCommitted}")
-    sed -e '/^skos/,+3d' "$fileToBeCommitted" > tmp$$
-    mv tmp$$ "$fileToBeCommitted"
-    chmod $permissions "${fileToBeCommitted}"
-    git add --update "${fileToBeCommitted}"
-  done
-
-  return 0
-}
 
 function main() {
   findBaseDir || return 1
@@ -242,7 +231,7 @@ function main() {
   findSerializerJar || return 3
 
   serialize_all || return 4
-  remove_skos_decls || return 5
+
 }
 
 main $*

--- a/tools/setup.cmd
+++ b/tools/setup.cmd
@@ -22,6 +22,11 @@ cp "${base_dir}/tools/pre-commit" "${base_dir}/.git/hooks/"
 # Make pre-commit hook executable. Needed at least on Mac, where the copied file is non-executable unless there's an existing executable file in the hooks directory, regardless of the status of the original file.
 chmod +x "${base_dir}/.git/hooks/pre-commit"
 
+# Copy serializer pre-commit to hooks directory. Needed for Mac, where the permissions on the file keep changing (after it executes?) and therefore GitHub detects.
+cp "${base_dir}/tools/serializer/pre-commit" "${base_dir}/.git/hooks/pre-commit-serializer"
+# Ensure that the serializer pre-commit hook is executable.
+chmod +x "${base_dir}/.git/hooks/pre-commit-serializer"
+
 # Exit linux shell
 exit
 


### PR DESCRIPTION
Fixes #1010.

The function corrupted binary files like PDFs and PNGs because it was called on any file, even those skipped by the serializer. Removing this function rather than modifying the call since we are going to remove it anyway as part of #934.