### PR TITLE
Ignore executable flag on files

### DIFF
--- a/docs/release_notes/PR1012-core-filemode-config
+++ b/docs/release_notes/PR1012-core-filemode-config
@@ -1,0 +1,3 @@
+### Patch Updates
+
+- Updated `setup.cmd` to configure git to ignore changes to executable flags on files.

--- a/tools/pre-commit
+++ b/tools/pre-commit
@@ -21,7 +21,7 @@ base_dir=$(git rev-parse --show-toplevel)
 # Run the serializer
 set -x
 
-"${base_dir}/.git/hooks/pre-commit-serializer"
+"${base_dir}/tools/serializer/pre-commit"
 
 rc=$?
 set +x

--- a/tools/setup.cmd
+++ b/tools/setup.cmd
@@ -27,7 +27,7 @@ cp "${base_dir}/tools/serializer/pre-commit-serializer" "${base_dir}/.git/hooks/
 # Ensure that the serializer pre-commit hook is executable.
 chmod +x "${base_dir}/.git/hooks/pre-commit-serializer"
 
-# Don't track executable flag on files. Needed on Mac, which makes files non-executable on commit. 
+# Don't track executable flag on files; this is a repository-specific setting. Needed on Mac, which makes files non-executable on commit. 
 git config core.filemode false
 
 # Exit linux shell

--- a/tools/setup.cmd
+++ b/tools/setup.cmd
@@ -22,10 +22,8 @@ cp "${base_dir}/tools/pre-commit" "${base_dir}/.git/hooks/"
 # Make pre-commit hook executable. 
 chmod +x "${base_dir}/.git/hooks/pre-commit"
 
-# Copy serializer pre-commit to hooks directory.
-cp "${base_dir}/tools/serializer/pre-commit-serializer" "${base_dir}/.git/hooks/pre-commit-serializer"
 # Ensure that the serializer pre-commit hook is executable.
-chmod +x "${base_dir}/.git/hooks/pre-commit-serializer"
+chmod +x "${base_dir}/tools/serializer/pre-commit"
 
 # Don't track executable flags on files in this repository (this is not a global setting). 
 git config core.filemode false

--- a/tools/setup.cmd
+++ b/tools/setup.cmd
@@ -19,7 +19,7 @@ set -x
 # Copy pre-commit to the git hooks directory
 cp "${base_dir}/tools/pre-commit" "${base_dir}/.git/hooks/"
 
-# Make pre-commit hook executable. Needed at least on Mac, where the copied file is non-executable unless there's an existing executable file in the hooks directory, regardless of the status of the original file.
+# Make pre-commit hook executable. 
 chmod +x "${base_dir}/.git/hooks/pre-commit"
 
 # Copy serializer pre-commit to hooks directory.
@@ -27,7 +27,7 @@ cp "${base_dir}/tools/serializer/pre-commit-serializer" "${base_dir}/.git/hooks/
 # Ensure that the serializer pre-commit hook is executable.
 chmod +x "${base_dir}/.git/hooks/pre-commit-serializer"
 
-# Don't track executable flag on files; this is a repository-specific setting. Needed on Mac, which makes files non-executable on commit. 
+# Don't track executable flags on files in this repository (this is not a global setting). 
 git config core.filemode false
 
 # Exit linux shell

--- a/tools/setup.cmd
+++ b/tools/setup.cmd
@@ -22,10 +22,13 @@ cp "${base_dir}/tools/pre-commit" "${base_dir}/.git/hooks/"
 # Make pre-commit hook executable. Needed at least on Mac, where the copied file is non-executable unless there's an existing executable file in the hooks directory, regardless of the status of the original file.
 chmod +x "${base_dir}/.git/hooks/pre-commit"
 
-# Copy serializer pre-commit to hooks directory. Needed for Mac, where the permissions on the file keep changing (after it executes?) and therefore GitHub detects.
-cp "${base_dir}/tools/serializer/pre-commit" "${base_dir}/.git/hooks/pre-commit-serializer"
+# Copy serializer pre-commit to hooks directory.
+cp "${base_dir}/tools/serializer/pre-commit-serializer" "${base_dir}/.git/hooks/pre-commit-serializer"
 # Ensure that the serializer pre-commit hook is executable.
 chmod +x "${base_dir}/.git/hooks/pre-commit-serializer"
+
+# Don't track executable flag on files. Needed on Mac, which makes files non-executable on commit. 
+git config core.filemode false
 
 # Exit linux shell
 exit


### PR DESCRIPTION
@Jamie-SA On Mac files become non-executable when committed. This means that you have to make setup.cmd executable to run it, at which point git records a change and wants to re-commit. Setting the flag in setup.cmd means git will ignore this change. 

See https://git-scm.com/docs/git-config#Documentation/git-config.txt-corefileMode and
https://stackoverflow.com/questions/1580596/how-do-i-make-git-ignore-file-mode-chmod-changes