### PR TITLE
Add skeletal definitions for SKOS terms

### DIFF
--- a/docs/release_notes/934-skeletal-definitions-for-DL.md
+++ b/docs/release_notes/934-skeletal-definitions-for-DL.md
@@ -1,0 +1,3 @@
+### Minor Updates
+
+- Added skeletal definitions for SKOS terms to achieve OWL DL compliance. Issue [#934](https://github.com/semanticarts/gist/issues/934).

--- a/gistCore.ttl
+++ b/gistCore.ttl
@@ -17,6 +17,18 @@
 	gist:license "https://creativecommons.org/licenses/by-sa/3.0/"^^xsd:string ;
 	.
 
+skos:definition
+	a owl:AnnotationProperty ;
+	.
+
+skos:example
+	a owl:AnnotationProperty ;
+	.
+
+skos:prefLabel
+	a owl:AnnotationProperty ;
+	.
+
 gist:Account
 	a owl:Class ;
 	owl:equivalentClass [

--- a/gistCore.ttl
+++ b/gistCore.ttl
@@ -29,6 +29,10 @@ skos:prefLabel
 	a owl:AnnotationProperty ;
 	.
 
+skos:scopeNote
+	a owl:AnnotationProperty ;
+	.
+
 gist:Account
 	a owl:Class ;
 	owl:equivalentClass [

--- a/validation/shapes/ontologyShapes.ttl
+++ b/validation/shapes/ontologyShapes.ttl
@@ -37,7 +37,7 @@ gshapes:ClassShape
 		a sh:SPARQLTarget ;
 		skos:definition "Target only non-blank node classes to avoid noise from OWL constructs."^^xsd:string ;
 		sh:prefixes <http://www.w3.org/2002/07/owl#> ;
-		sh:select "SELECT $this WHERE { $this a owl:Class . filter(!isblank($this)) }"^^xsd:string ;
+		sh:select "SELECT $this WHERE { $this a owl:Class . filter(!isblank($this) && contains(str($this), 'gist')) }"^^xsd:string ;
 	] ;
 	.
 
@@ -114,11 +114,12 @@ gshapes:PropertyShape
 		gshapes:NonConformingLabel
 	) ;
 	sh:property gshapes:MandatoryDefinition ;
-	sh:targetClass
-		owl:AnnotationProperty ,
-		owl:DatatypeProperty ,
-		owl:ObjectProperty
-		;
+	sh:target [
+		a sh:SPARQLTarget ;
+		skos:definition "Target only properties in the gist namespace."^^xsd:string ;
+		sh:prefixes <http://www.w3.org/2002/07/owl#> ;
+		sh:select "SELECT $this WHERE { $this a ?property_type . values ?property_type { owl:DatatypeProperty owl:ObjectProperty owl:AnnotationProperty } filter(contains(str($this), 'gist')) }"^^xsd:string ;
+	] ;
 	.
 
 gshapes:SentenceCase

--- a/validation/shapes/ontologyShapes.ttl
+++ b/validation/shapes/ontologyShapes.ttl
@@ -116,9 +116,9 @@ gshapes:PropertyShape
 	sh:property gshapes:MandatoryDefinition ;
 	sh:target [
 		a sh:SPARQLTarget ;
-		skos:definition "Target only properties in the gist namespace."^^xsd:string ;
+		skos:definition "Target all OWL properties in the gist namespace."^^xsd:string ;
 		sh:prefixes <http://www.w3.org/2002/07/owl#> ;
-		sh:select "SELECT $this WHERE { $this a ?property_type . values ?property_type { owl:DatatypeProperty owl:ObjectProperty owl:AnnotationProperty } filter(contains(str($this), 'gist')) }"^^xsd:string ;
+		sh:select "SELECT $this WHERE { $this a ?property_type . VALUES ?property_type { owl:DatatypeProperty owl:ObjectProperty owl:AnnotationProperty } FILTER(CONTAINS(STR($this), 'gist')) }"^^xsd:string ;
 	] ;
 	.
 

--- a/validation/shapes/ontologyShapes.ttl
+++ b/validation/shapes/ontologyShapes.ttl
@@ -35,7 +35,7 @@ gshapes:ClassShape
 	sh:property gshapes:MandatoryDefinition ;
 	sh:target [
 		a sh:SPARQLTarget ;
-		skos:definition "Target only non-blank node classes to avoid noise from OWL constructs."^^xsd:string ;
+		skos:definition "Target only classes in gist namespace. Filter out blank node classes to avoid noise from OWL constructs."^^xsd:string ;
 		sh:prefixes <http://www.w3.org/2002/07/owl#> ;
 		sh:select "SELECT $this WHERE { $this a owl:Class . filter(!isblank($this) && contains(str($this), 'gist')) }"^^xsd:string ;
 	] ;

--- a/validation/shapes/ontologyShapes.ttl
+++ b/validation/shapes/ontologyShapes.ttl
@@ -35,7 +35,7 @@ gshapes:ClassShape
 	sh:property gshapes:MandatoryDefinition ;
 	sh:target [
 		a sh:SPARQLTarget ;
-		skos:definition "Target only classes in gist namespace. Filter out blank node classes to avoid noise from OWL constructs."^^xsd:string ;
+		skos:definition "Target only classes in the gist namespace."^^xsd:string ;
 		sh:prefixes <http://www.w3.org/2002/07/owl#> ;
 		sh:select "SELECT $this WHERE { $this a owl:Class . FILTER(!isblank($this) && CONTAINS(STR($this), 'gist')) }"^^xsd:string ;
 	] ;

--- a/validation/shapes/ontologyShapes.ttl
+++ b/validation/shapes/ontologyShapes.ttl
@@ -37,7 +37,7 @@ gshapes:ClassShape
 		a sh:SPARQLTarget ;
 		skos:definition "Target only classes in gist namespace. Filter out blank node classes to avoid noise from OWL constructs."^^xsd:string ;
 		sh:prefixes <http://www.w3.org/2002/07/owl#> ;
-		sh:select "SELECT $this WHERE { $this a owl:Class . filter(!isblank($this) && contains(str($this), 'gist')) }"^^xsd:string ;
+		sh:select "SELECT $this WHERE { $this a owl:Class . FILTER(!isblank($this) && CONTAINS(STR($this), 'gist')) }"^^xsd:string ;
 	] ;
 	.
 


### PR DESCRIPTION
Adding skeletal definitions for SKOS terms. Omitting definitions for SHACL terms in anticipation of #1001.

Closes #934.