### PR TITLE
Add release note for issue 865 (change branch master to main)

### DIFF
--- a/docs/release_notes/issue865-rename-master-to-main.md
+++ b/docs/release_notes/issue865-rename-master-to-main.md
@@ -1,0 +1,3 @@
+### Patch Updates
+
+- Renamed branch `master` to `main`. Issue [#865](https://github.com/semanticarts/gist/issues/865).


### PR DESCRIPTION
Closes #865.

Branch has been renamed - this PR adds a release note.

Steps to update:
- Fetch the remote
- Track branch `main`
- Delete local branch `master`