### PR TITLE
Back out major changes from 12.1.0 release

### DIFF
--- a/docs/release_notes/issue-878-TemporalRelation-drop-endDate-restriction.md
+++ b/docs/release_notes/issue-878-TemporalRelation-drop-endDate-restriction.md
@@ -1,3 +1,0 @@
-### Minor Updates
-
-- Removed `gist:endDateTime` restriction from the formal definition of `gist:TemporalRelation`. Issue [#878](https://github.com/semanticarts/gist/issues/878).

--- a/docs/release_notes/issue-925-TimeInterval-duration-restriction.md
+++ b/docs/release_notes/issue-925-TimeInterval-duration-restriction.md
@@ -1,3 +1,0 @@
-### Major Updates
-
-- Added `gist:startDateTime`, `gist:endDateTime`, and `gist:Duration` restrictions to the formal definition of `gist:TimeInterval`. Issue [#925](https://github.com/semanticarts/gist/issues/925).

--- a/ontologies/gistCore.ttl
+++ b/ontologies/gistCore.ttl
@@ -2465,6 +2465,11 @@ gist:TemporalRelation
 	rdfs:subClassOf
 		[
 			a owl:Restriction ;
+			owl:onProperty gist:endDateTime ;
+			owl:cardinality "1"^^xsd:nonNegativeInteger ;
+		] ,
+		[
+			a owl:Restriction ;
 			owl:onProperty gist:startDateTime ;
 			owl:cardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
@@ -2507,24 +2512,6 @@ gist:Text
 
 gist:TimeInterval
 	a owl:Class ;
-	rdfs:subClassOf
-		[
-			a owl:Restriction ;
-			owl:onProperty gist:actualEndDateTime ;
-			owl:cardinality "1"^^xsd:nonNegativeInteger ;
-		] ,
-		[
-			a owl:Restriction ;
-			owl:onProperty gist:actualStartDateTime ;
-			owl:cardinality "1"^^xsd:nonNegativeInteger ;
-		] ,
-		[
-			a owl:Restriction ;
-			owl:onProperty gist:hasMagnitude ;
-			owl:onClass gist:Duration ;
-			owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
-		]
-		;
 	skos:definition "A span of time with a known start time, end time, and duration. As long as two of the three are known, the third can be inferred."^^xsd:string ;
 	skos:example "7pm to 9pm on Jan 1, 2001; fiscal year 2023; the week starting at midnight of January 12, 2023 and lasting exactly 168 hours."^^xsd:string ;
 	skos:prefLabel "Time Interval"^^xsd:string ;


### PR DESCRIPTION
A couple major changes (#969 & #970) were merged into develop prior to the 12.1.0 minor release. To keep the release at the minor level, this PR backs out these major changes.

The changes are set to be added back in major release 13.0.0. See #1046.