### PR TITLE
Removed domain and range from gist:isGovernedBy

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -1,5 +1,8 @@
 # gist Release Notes
 
+## Release 13.0.0
+-Removed domain and range from `gist:isGovernedBy`. Issue [899] (https://github.com/semanticarts/gist/issues/899)
+
 ## Release 12.1.0
 
 ### Minor Updates

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -1,8 +1,5 @@
 # gist Release Notes
 
-## Release 13.0.0
--Removed domain and range from `gist:isGovernedBy`. Issue [899] (https://github.com/semanticarts/gist/issues/899)
-
 ## Release 12.1.0
 
 ### Minor Updates

--- a/docs/release_notes/Issue-899-isGovernedBy.md
+++ b/docs/release_notes/Issue-899-isGovernedBy.md
@@ -1,2 +1,4 @@
-Removed domain and range from gist:isGovernedBy
-Issue [899] (https://github.com/semanticarts/gist/issues/899)
+### Major Updates
+
+- Removed domain and range from `gist:isGovernedBy`
+  Issue [899] (https://github.com/semanticarts/gist/issues/899)

--- a/docs/release_notes/Issue-899-isGovernedBy.md
+++ b/docs/release_notes/Issue-899-isGovernedBy.md
@@ -1,4 +1,3 @@
 ### Major Updates
 
-- Removed domain and range from `gist:isGovernedBy`
-  Issue [899] (https://github.com/semanticarts/gist/issues/899)
+- Removed domain and range from `gist:isGovernedBy`. Issue [899](https://github.com/semanticarts/gist/issues/899).

--- a/docs/release_notes/Issue-899-isGovernedBy.md
+++ b/docs/release_notes/Issue-899-isGovernedBy.md
@@ -1,0 +1,2 @@
+Removed domain and range from gist:isGovernedBy
+Issue [899] (https://github.com/semanticarts/gist/issues/899)

--- a/ontologies/gistCore.ttl
+++ b/ontologies/gistCore.ttl
@@ -3446,29 +3446,6 @@ gist:isGeographicallyContainedIn
 
 gist:isGovernedBy
 	a owl:ObjectProperty ;
-	rdfs:domain [
-		a owl:Class ;
-		owl:unionOf (
-			gist:Category
-			gist:Content
-			gist:GeoRegion
-			gist:IntellectualProperty
-			gist:Intention
-			gist:Organization
-			gist:Person
-			gist:PhysicalIdentifiableItem
-			gist:PhysicalSubstance
-		) ;
-	] ;
-	rdfs:range [
-		a owl:Class ;
-		owl:unionOf (
-			gist:Intention
-			gist:Organization
-			gist:Person
-			gist:Template
-		) ;
-	] ;
 	skos:definition "A reference from the thing being governed to the governor"^^xsd:string ;
 	skos:prefLabel "is governed by"^^xsd:string ;
 	.


### PR DESCRIPTION
Fixes #899
Removed domain and range from gist:isGovernedBy
