### PR TITLE
Bugfix/issue 944: tweaks to ordered member and has first member

### DIFF
--- a/docs/release_notes/Issue-944-tweaks-to-OrderedMember-and-hasFirstMember.md
+++ b/docs/release_notes/Issue-944-tweaks-to-OrderedMember-and-hasFirstMember.md
@@ -1,6 +1,6 @@
 ### Major Updates
-- Added `gist:providesOrderFor` restriction to `gist:OrderedMember`. Issue [944](https://github.com/semanticarts/gist/issues/944)
-- Changed filter class for `gist:hasFirstMember` restriction on `gist:OrderedCollection` from `owl:Thing` to `gist:OrderedMember`. Issue [944](https://github.com/semanticarts/gist/issues/944)
+- Added `gist:providesOrderFor` restriction to `gist:OrderedMember`. Issue [944](https://github.com/semanticarts/gist/issues/944).
+- Changed filter class for `gist:hasFirstMember` restriction on `gist:OrderedCollection` from `owl:Thing` to `gist:OrderedMember`. Issue [944](https://github.com/semanticarts/gist/issues/944).
 
 ### Patch Updates
-- Adjusted `skos:scopeNote` for `gist:hasFirstMember`: updated language to reflect that strict orderings *are* allowed.  Issue [944](https://github.com/semanticarts/gist/issues/944)
+- Adjusted `skos:scopeNote` for `gist:hasFirstMember`: updated language to reflect that strict orderings *are* allowed.  Issue [944](https://github.com/semanticarts/gist/issues/944).

--- a/docs/release_notes/Issue-944-tweaks-to-OrderedMember-and-hasFirstMember.md
+++ b/docs/release_notes/Issue-944-tweaks-to-OrderedMember-and-hasFirstMember.md
@@ -1,6 +1,6 @@
 ### Major Updates
-- added `providesOrderFor` restriction to `OrderedMember`
-- change filter class for `hasFirstMember` restriction on `OrderedCollection` from `owl:Thing` to `OrderedMember`. Issue [944](https://github.com/semanticarts/gist/issues/944)
+- Added `gist:providesOrderFor` restriction to `gist:OrderedMember`. Issue [944](https://github.com/semanticarts/gist/issues/944)
+- Changed filter class for `gist:hasFirstMember` restriction on `gist:OrderedCollection` from `owl:Thing` to `gist:OrderedMember`. Issue [944](https://github.com/semanticarts/gist/issues/944)
 
 ### Patch Updates
-- tweaked `scopeNote` for `hasFirstMember`: updated language to reflect that strict orderings *are* allowed.  Issue [944](https://github.com/semanticarts/gist/issues/944)
+- Adjusted `skos:scopeNote` for `gist:hasFirstMember`: updated language to reflect that strict orderings *are* allowed.  Issue [944](https://github.com/semanticarts/gist/issues/944)

--- a/docs/release_notes/Issue-944-tweaks-to-OrderedMember-and-hasFirstMember.md
+++ b/docs/release_notes/Issue-944-tweaks-to-OrderedMember-and-hasFirstMember.md
@@ -1,0 +1,6 @@
+### Major Updates
+
+- tweaked `scopeNote` for `hasFirstMember`: updated language to reflect that strict orderings *are* allowed
+- added `providesOrderFor` restriction to `OrderedMember`
+- change filter class for `hasFirstMember` restriction on `OrderedCollection` from `owl:Thing` to `OrderedMember`
+Issue [944](https://github.com/semanticarts/gist/issues/944)

--- a/docs/release_notes/Issue-944-tweaks-to-OrderedMember-and-hasFirstMember.md
+++ b/docs/release_notes/Issue-944-tweaks-to-OrderedMember-and-hasFirstMember.md
@@ -1,6 +1,6 @@
 ### Major Updates
-
-- tweaked `scopeNote` for `hasFirstMember`: updated language to reflect that strict orderings *are* allowed
 - added `providesOrderFor` restriction to `OrderedMember`
-- change filter class for `hasFirstMember` restriction on `OrderedCollection` from `owl:Thing` to `OrderedMember`
-Issue [944](https://github.com/semanticarts/gist/issues/944)
+- change filter class for `hasFirstMember` restriction on `OrderedCollection` from `owl:Thing` to `OrderedMember`. Issue [944](https://github.com/semanticarts/gist/issues/944)
+
+### Patch Updates
+- tweaked `scopeNote` for `hasFirstMember`: updated language to reflect that strict orderings *are* allowed.  Issue [944](https://github.com/semanticarts/gist/issues/944)

--- a/ontologies/gistCore.ttl
+++ b/ontologies/gistCore.ttl
@@ -1750,7 +1750,7 @@ gist:OrderedCollection
 					[
 						a owl:Restriction ;
 						owl:onProperty gist:hasFirstMember ;
-						owl:someValuesFrom owl:OrderedMember ;
+						owl:someValuesFrom gist:OrderedMember ;
 					]
 					[
 						a owl:Restriction ;

--- a/ontologies/gistCore.ttl
+++ b/ontologies/gistCore.ttl
@@ -1773,7 +1773,6 @@ gist:OrderedCollection
 
 gist:OrderedMember
 	a owl:Class ;
-	rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
 	owl:equivalentClass [
 		a owl:Class ;
 		owl:intersectionOf (

--- a/ontologies/gistCore.ttl
+++ b/ontologies/gistCore.ttl
@@ -1750,7 +1750,7 @@ gist:OrderedCollection
 					[
 						a owl:Restriction ;
 						owl:onProperty gist:hasFirstMember ;
-						owl:someValuesFrom owl:Thing ;
+						owl:someValuesFrom owl:OrderedMember ;
 					]
 					[
 						a owl:Restriction ;

--- a/ontologies/gistCore.ttl
+++ b/ontologies/gistCore.ttl
@@ -1773,9 +1773,15 @@ gist:OrderedCollection
 
 gist:OrderedMember
 	a owl:Class ;
+	rdfs:isDefinedBy <https://w3id.org/semanticarts/ontology/gistCore> ;
 	owl:equivalentClass [
 		a owl:Class ;
 		owl:intersectionOf (
+			[
+        		a owl:Restriction ;
+        		owl:onProperty gist:providesOrderFor ;
+        		owl:someValuesFrom owl:Thing ;
+			]
 			[
 				a owl:Class ;
 				owl:unionOf (

--- a/ontologies/gistCore.ttl
+++ b/ontologies/gistCore.ttl
@@ -1778,9 +1778,9 @@ gist:OrderedMember
 		a owl:Class ;
 		owl:intersectionOf (
 			[
-        		a owl:Restriction ;
-        		owl:onProperty gist:providesOrderFor ;
-        		owl:someValuesFrom owl:Thing ;
+				a owl:Restriction ;
+				owl:onProperty gist:providesOrderFor ;
+				owl:someValuesFrom owl:Thing ;
 			]
 			[
 				a owl:Class ;

--- a/ontologies/gistCore.ttl
+++ b/ontologies/gistCore.ttl
@@ -3157,7 +3157,7 @@ gist:hasFirstMember
 	rdfs:range gist:OrderedMember ;
 	skos:definition "Relates an ordered collection to its first member."^^xsd:string ;
 	skos:prefLabel "has first member"^^xsd:string ;
-	skos:scopeNote "Given the Open World Assumption, the absence of a predecessor does not entail that an ordered member is the first member of an ordered collection. This property is used to explicitly indicate the first member. Since ordered collections may not be strictly ordered, there can be more than one first member."^^xsd:string ;
+	skos:scopeNote "Given the Open World Assumption, the absence of a predecessor does not entail that an ordered member is the first member of an ordered collection. This property is used to explicitly indicate the first member. Since ordered collections need not be strictly ordered, there can be more than one first member."^^xsd:string ;
 	.
 
 gist:hasGiver


### PR DESCRIPTION
Fixes #944
- tweaked `scopeNote` for `hasFirstMember`: updated language to reflect that strict orderings *are* allowed
- added `providesOrderFor` restriction to `OrderedMember`
- change filter class for `hasFirstMember` restriction on `OrderedCollection` from `owl:Thing` to `OrderedMember`