### PR TITLE
Feature/new issue 831 add event specification

### DIFF
--- a/docs/release_notes/Issue-831-EventSpecification.md
+++ b/docs/release_notes/Issue-831-EventSpecification.md
@@ -1,0 +1,7 @@
+## Release 13.0.0
+
+### Major Updates
+
+### Minor Updates
+- Added EventSpeciifcation [#831](https://github.com/semanticarts/gist/issues/831).
+- Added and updated annotations for Specification Issue [#831](https://github.com/semanticarts/gist/issues/831).

--- a/docs/release_notes/Issue-831-EventSpecification.md
+++ b/docs/release_notes/Issue-831-EventSpecification.md
@@ -1,7 +1,8 @@
+
 ## Release 13.0.0
 
 ### Major Updates
 
 ### Minor Updates
-- Added EventSpeciifcation [#831](https://github.com/semanticarts/gist/issues/831).
-- Added and updated annotations for Specification Issue [#831](https://github.com/semanticarts/gist/issues/831).
+- Added `EventSpecification` [#831](https://github.com/semanticarts/gist/issues/831).
+- Added and updated annotations for `Specification` [#831](https://github.com/semanticarts/gist/issues/831).

--- a/docs/release_notes/Issue-831-EventSpecification.md
+++ b/docs/release_notes/Issue-831-EventSpecification.md
@@ -4,5 +4,5 @@
 ### Major Updates
 
 ### Minor Updates
-- Added `EventSpecification` [#831](https://github.com/semanticarts/gist/issues/831).
-- Added and updated annotations for `Specification` [#831](https://github.com/semanticarts/gist/issues/831).
+- Added `gist:EventSpecification`. Issue [#831](https://github.com/semanticarts/gist/issues/831).
+- Added and updated annotations for `gist:Specification`. Issue [#831](https://github.com/semanticarts/gist/issues/831).

--- a/docs/release_notes/Issue-831-EventSpecification.md
+++ b/docs/release_notes/Issue-831-EventSpecification.md
@@ -2,7 +2,9 @@
 ## Release 13.0.0
 
 ### Major Updates
+- `gist:Specification` is now a direct subclass of `gist:Intention`. Issue [#831](https://github.com/semanticarts/gist/issues/831)
 
 ### Minor Updates
+- Updated definition of `gist:Requirement`. Issue [#831](https://github.com/semanticarts/gist/issues/831)
 - Added `gist:EventSpecification`. Issue [#831](https://github.com/semanticarts/gist/issues/831).
 - Added and updated annotations for `gist:Specification`. Issue [#831](https://github.com/semanticarts/gist/issues/831).

--- a/ontologies/gistCore.ttl
+++ b/ontologies/gistCore.ttl
@@ -2255,8 +2255,10 @@ gist:SimpleUnitOfMeasure
 gist:Specification
 	a owl:Class ;
 	rdfs:subClassOf gist:Requirement ;
-	skos:definition "One or more requirements to be satisfied by a material, design, product, or service."^^xsd:string ;
+	skos:definition "One or more characteristics that specify what it means to be a particular type of thing such as a material, product, service or event. A specification is sufficiently precise to allow conformance of something to the specification to be tested."^^xsd:string ;
+	skos:example "The specification of the iPhone 14; hypothetical events covered by a home owner's insurance policy."^^xsd:string ;
 	skos:prefLabel "Specification"^^xsd:string ;
+	skos:scopeNote "Although a characterization of how to do something is often called a specification, the intended meaning here is limited to specifying what something is. The focus is on the what, not the how. Use the task template class for specifying the how, such as a plan or process specification."^^xsd:string ;
 	.
 
 gist:StreetAddress

--- a/ontologies/gistCore.ttl
+++ b/ontologies/gistCore.ttl
@@ -2258,7 +2258,7 @@ gist:Specification
 	skos:definition "One or more characteristics that specify what it means to be a particular type of thing such as a material, product, service or event. A specification is sufficiently precise to allow evaluating conformance to the specification."^^xsd:string ;
 	skos:example "The specification of the iPhone 14; hypothetical events covered by a homeowner's insurance policy."^^xsd:string ;
 	skos:prefLabel "Specification"^^xsd:string ;
-	skos:scopeNote "Although a characterization of how to do something is often called a specification, the intended meaning here is limited to specifying what something is. The focus is on the what, not the how. Use the task template class for specifying the how, such as a plan or process specification."^^xsd:string ;
+	skos:scopeNote "Although a characterization of how to do something is often called a specification, the intended meaning here is limited to specifying what something is. The focus is on the what, not the how. Use the TaskTemplate class for specifying the how, such as a plan or process specification."^^xsd:string ;
 	.
 
 gist:StreetAddress

--- a/ontologies/gistCore.ttl
+++ b/ontologies/gistCore.ttl
@@ -948,7 +948,7 @@ gist:EventSpecification
 	a owl:Class ;
 	rdfs:subClassOf gist:Specification ;
 	skos:definition "A characterization of an event that might happen."^^xsd:string ;
-	skos:example "A hail storm that is covered by an insurance policy.  Someone defaults on a loan."^^xsd:string ;
+	skos:example "An insurance company defines the characteristics of a weather event that must be satisfied for it to qualify as a hail storm covered in its homeowner's policy. Defaulting on a loan."^^xsd:string ;
 	skos:prefLabel "Event Specification"^^xsd:string ;
 	skos:scopeNote "This concept is useful for risk assessment and insurance policies."^^xsd:string ;
 	.

--- a/ontologies/gistCore.ttl
+++ b/ontologies/gistCore.ttl
@@ -2143,7 +2143,7 @@ gist:RenderedContent
 gist:Requirement
 	a owl:Class ;
 	rdfs:subClassOf gist:Intention ;
-	skos:definition "A documented physical or functional need that a particular design, product, or process must be able to perform.  Alternately, the obligation of a person or organization to behave in a certain way (i.e., drive on the right side of the road)."^^xsd:string ;
+	skos:definition "The obligation of a person or organization to behave in a certain way (e.g., drive on the right side of the road)."^^xsd:string ;
 	skos:prefLabel "Requirement"^^xsd:string ;
 	.
 
@@ -2254,7 +2254,7 @@ gist:SimpleUnitOfMeasure
 
 gist:Specification
 	a owl:Class ;
-	rdfs:subClassOf gist:Requirement ;
+	rdfs:subClassOf gist:Intention ;
 	skos:definition "One or more characteristics that specify what it means to be a particular type of thing such as a material, product, service or event. A specification is sufficiently precise to allow evaluating conformance to the specification."^^xsd:string ;
 	skos:example "The specification of the iPhone 14; hypothetical events covered by a homeowner's insurance policy."^^xsd:string ;
 	skos:prefLabel "Specification"^^xsd:string ;

--- a/ontologies/gistCore.ttl
+++ b/ontologies/gistCore.ttl
@@ -944,6 +944,15 @@ gist:Event
 		;
 	.
 
+gist:EventSpecification
+	a owl:Class ;
+	rdfs:subClassOf gist:Specification ;
+	skos:definition "A characterization of an event that might happen."^^xsd:string ;
+	skos:example "A hail storm that is covered by an insurance policy.  Someone defaults on a loan."^^xsd:string ;
+	skos:prefLabel "Event Specification"^^xsd:string ;
+	skos:scopeNote "It is useful for risk assessment and insurance policies."^^xsd:string ;
+	.
+
 gist:Extent
 	a owl:Class ;
 	owl:equivalentClass [

--- a/ontologies/gistCore.ttl
+++ b/ontologies/gistCore.ttl
@@ -950,7 +950,7 @@ gist:EventSpecification
 	skos:definition "A characterization of an event that might happen."^^xsd:string ;
 	skos:example "A hail storm that is covered by an insurance policy.  Someone defaults on a loan."^^xsd:string ;
 	skos:prefLabel "Event Specification"^^xsd:string ;
-	skos:scopeNote "It is useful for risk assessment and insurance policies."^^xsd:string ;
+	skos:scopeNote "This concept is useful for risk assessment and insurance policies."^^xsd:string ;
 	.
 
 gist:Extent
@@ -2255,8 +2255,8 @@ gist:SimpleUnitOfMeasure
 gist:Specification
 	a owl:Class ;
 	rdfs:subClassOf gist:Requirement ;
-	skos:definition "One or more characteristics that specify what it means to be a particular type of thing such as a material, product, service or event. A specification is sufficiently precise to allow testing conformance to the specification."^^xsd:string ;
-	skos:example "The specification of the iPhone 14; hypothetical events covered by a home owner's insurance policy."^^xsd:string ;
+	skos:definition "One or more characteristics that specify what it means to be a particular type of thing such as a material, product, service or event. A specification is sufficiently precise to allow evaluating conformance to the specification."^^xsd:string ;
+	skos:example "The specification of the iPhone 14; hypothetical events covered by a homeowner's insurance policy."^^xsd:string ;
 	skos:prefLabel "Specification"^^xsd:string ;
 	skos:scopeNote "Although a characterization of how to do something is often called a specification, the intended meaning here is limited to specifying what something is. The focus is on the what, not the how. Use the task template class for specifying the how, such as a plan or process specification."^^xsd:string ;
 	.

--- a/ontologies/gistCore.ttl
+++ b/ontologies/gistCore.ttl
@@ -2255,7 +2255,7 @@ gist:SimpleUnitOfMeasure
 gist:Specification
 	a owl:Class ;
 	rdfs:subClassOf gist:Intention ;
-	skos:definition "One or more characteristics that specify what it means to be a particular type of thing such as a material, product, service or event. A specification is sufficiently precise to allow evaluating conformance to the specification."^^xsd:string ;
+	skos:definition "One or more characteristics that specify what it means to be a particular type of thing, such as a material, product, service or event. A specification is sufficiently precise to allow evaluating conformance to the specification."^^xsd:string ;
 	skos:example "The specification of the iPhone 14; hypothetical events covered by a homeowner's insurance policy."^^xsd:string ;
 	skos:prefLabel "Specification"^^xsd:string ;
 	skos:scopeNote "Although a characterization of how to do something is often called a specification, the intended meaning here is limited to specifying what something is. The focus is on the what, not the how. Use the TaskTemplate class for specifying the how, such as a plan or process specification."^^xsd:string ;

--- a/ontologies/gistCore.ttl
+++ b/ontologies/gistCore.ttl
@@ -2255,7 +2255,7 @@ gist:SimpleUnitOfMeasure
 gist:Specification
 	a owl:Class ;
 	rdfs:subClassOf gist:Requirement ;
-	skos:definition "One or more characteristics that specify what it means to be a particular type of thing such as a material, product, service or event. A specification is sufficiently precise to allow conformance of something to the specification to be tested."^^xsd:string ;
+	skos:definition "One or more characteristics that specify what it means to be a particular type of thing such as a material, product, service or event. A specification is sufficiently precise to allow testing conformance to the specification."^^xsd:string ;
 	skos:example "The specification of the iPhone 14; hypothetical events covered by a home owner's insurance policy."^^xsd:string ;
 	skos:prefLabel "Specification"^^xsd:string ;
 	skos:scopeNote "Although a characterization of how to do something is often called a specification, the intended meaning here is limited to specifying what something is. The focus is on the what, not the how. Use the task template class for specifying the how, such as a plan or process specification."^^xsd:string ;


### PR DESCRIPTION
Fixes #831 
- Added `EventSpecification`.
- Added and updated annotations for `Specification`.

OPEN QUESTION: there is now an incorrect subclass relationship.

`Requirement`: gist 12.0: 
- "A documented physical or functional need that a particular design, product, or process must be able to perform.  Alternately, the obligation of a person or organization to behave in a certain way (i.e., drive on the right side of the road)."

Updated definition of `Specification`:
- "One or more characteristics that specify what it means to be a particular type of thing such as a material, product, service or event. A specification is sufficiently precise to allow conformance of something to the specification to be tested."

A Specification is often not a need to be performed, so Specification cannot be a subclass of Requirement.  It includes the idea of a law or regulation which is outside the scope of a specification.
 
Options include:
1. Broaden the definition of Requirement to include Specification so the subclass relationship can remain. Easier said than done. 
2. Remove the class Requirement, it's never been use in my experience, if anyone want to represent a law or regulation, they can create a separate subclass.
