### PR TITLE
Remove occupies predicates and shorten isGeographicallyContainedIn 

### DIFF
--- a/docs/gistStyleGuide.md
+++ b/docs/gistStyleGuide.md
@@ -12,6 +12,7 @@
   - [Classes](#classes)
   - [Properties](#properties)
   - [Valid Exceptions](#valid-exceptions)
+  - [gist:nonConformingLabel](#gistnonconforminglabel)
   - [gist Definition of Title Case](#gist-definition-of-title-case)
 - [Annotations](#annotations)
   - [Conventions for Use](#conventions-for-use)
@@ -131,14 +132,17 @@ The following conventions apply to `skos:prefLabel` but *not* `skos:altLabel`, w
 
 - Lower case
 - Normalized to natural language standards. E.g., hyphens inserted, acronyms in all caps, proper nouns capitalized, etc.
-- Examples: *has unit of measure*, *has SSN*
+- Examples: *has unit of measure*, *has SSN*, *Unicode symbol*, *W2*
 
 ### Valid Exceptions
 
 There may occasionally be valid reasons to deviate from the conventions stated here:
 
 - Deviation from wording of the local name. For example, the predicate `gist:isGeoContainedIn` uses a shortened form of "geographically" for conciseness. The `skos:prefLabel` uses the fully spelled out word: "is geographically contained in."
-- Deviation from typographical conventions such as case. For example, a proper name in a property label could appropriately be capitalized. Since this will fail the SHACL validation constraints during the ontology build and release process, add the term to the `gistValidationAnnotations.ttl` file so that label validation will be skipped.
+
+### gist:nonConformingLabel
+
+- The general label conventions have been captured in SHACL shapes which are run during the ontology build and release process and the repository continuous integration script. These shapes do not allow for special cases like capitalized proper names. To prevent validation failures, add the annotation `gist:nonConformingLabel true` to the term in the `gistValidationAnnotations` ontology so that label validation will be skipped.
 
 ### gist Definition of Title Case
 

--- a/docs/gistStyleGuide.md
+++ b/docs/gistStyleGuide.md
@@ -81,7 +81,7 @@ Some of the examples resulted in changes to gist `10.0.0`, others are hypothetic
 || `usesTimeZoneStandard`, not `timeZoneStandardUsed` |
 | Prefix "is" to "-ed" forms, both past participles and adjectives | `isGovernedBy`, not `governedBy` |
 || `isCharacterizedBy`, not `characterizedBy` |
-| Prefer an ordinary verb to "hasX" or "isX", even in a pair of inverses | `follows`, not `isPrecededBy`, even when inverse `precedes` exists |
+| Prefer an ordinary verb to "hasX" or "isX" | `precedes`, not `isFollowedBy` |
 | "At" rather than "on" for datetimes | `isRecordedAt`, not `isRecordedOn`. |
 | Present tense only with minimal exceptions when the meaning is inherently in the past | `isRenderedOn`, not `wasRenderedOn`, but `wasLastModifiedBy` rather than `isLastModifiedBy` |
 || `precedes`, not `preceded` |

--- a/docs/gistStyleGuide.md
+++ b/docs/gistStyleGuide.md
@@ -11,6 +11,7 @@
 - [Labels](#labels)
   - [Classes](#classes)
   - [Properties](#properties)
+  - [Valid Exceptions](#valid-exceptions)
   - [gist Definition of Title Case](#gist-definition-of-title-case)
 - [Annotations](#annotations)
   - [Conventions for Use](#conventions-for-use)
@@ -118,7 +119,7 @@ Note: As of version 12.0.0, gist itself does not itself follow the infix convent
 
 ## Labels
 
-*The* following conventions apply to `skos:prefLabel` but *not* `skos:altLabel`.
+The following conventions apply to `skos:prefLabel` but *not* `skos:altLabel`, which by nature may be idiosyncratic.
 
 ### Classes
 
@@ -131,6 +132,11 @@ Note: As of version 12.0.0, gist itself does not itself follow the infix convent
 - Lower case
 - Normalized to natural language standards. E.g., hyphens inserted, acronyms in all caps, proper nouns capitalized, etc.
 - Examples: *has unit of measure*, *has SSN*, *unit symbol Unicode*
+- In some cases the label may deviate lexically from the local name. For example, the predicate `gist:isGeoContainedIn` uses a shortened form of "geographically" for conciseness. The `skos:prefLabel` uses the fully spelled out word: "is geographically contained in."
+
+### Valid Exceptions
+
+Occasionally there is a valid reason to deviate from the label format conventions. Since this will fail the SHACL validation constraints applied to `skos:prefLabel`s during the ontology build and release process, add the predicate to the `gistValidationAnnotations.ttl` file so that label validation will be skipped.
 
 ### gist Definition of Title Case
 

--- a/docs/gistStyleGuide.md
+++ b/docs/gistStyleGuide.md
@@ -131,12 +131,14 @@ The following conventions apply to `skos:prefLabel` but *not* `skos:altLabel`, w
 
 - Lower case
 - Normalized to natural language standards. E.g., hyphens inserted, acronyms in all caps, proper nouns capitalized, etc.
-- Examples: *has unit of measure*, *has SSN*, *unit symbol Unicode*
-- In some cases the label may deviate lexically from the local name. For example, the predicate `gist:isGeoContainedIn` uses a shortened form of "geographically" for conciseness. The `skos:prefLabel` uses the fully spelled out word: "is geographically contained in."
+- Examples: *has unit of measure*, *has SSN*
 
 ### Valid Exceptions
 
-Occasionally there is a valid reason to deviate from the label format conventions. Since this will fail the SHACL validation constraints applied to `skos:prefLabel`s during the ontology build and release process, add the predicate to the `gistValidationAnnotations.ttl` file so that label validation will be skipped.
+There may occasionally be valid reasons to deviate from the conventions stated here:
+
+- Deviation from wording of the local name. For example, the predicate `gist:isGeoContainedIn` uses a shortened form of "geographically" for conciseness. The `skos:prefLabel` uses the fully spelled out word: "is geographically contained in."
+- Deviation from typographical conventions such as case. For example, a proper name in a property label could appropriately be capitalized. Since this will fail the SHACL validation constraints during the ontology build and release process, add the term to the `gistValidationAnnotations.ttl` file so that label validation will be skipped.
 
 ### gist Definition of Title Case
 

--- a/docs/release_notes/issue812-geo-predicates
+++ b/docs/release_notes/issue812-geo-predicates
@@ -1,0 +1,4 @@
+### Major Updates
+
+- Removed `gist:occupiesGeographically` and `gist:occupiesGeographicallyPermanently`, and replaced with `gist:hasPhysicalLocation` in class restriction. Issue [#809](https://github.com/semanticarts/gist/issues/809).
+- Shortened local name of `gist:isGeographicallyContainedin` to `isGeoContainedin`. Issue [#812](https://github.com/semanticarts/gist/issues/812).

--- a/docs/release_notes/issue812-geo-predicates
+++ b/docs/release_notes/issue812-geo-predicates
@@ -5,4 +5,4 @@
 
 ### Patch Updates
 
-- Added notes on exceptions to `skos:prefLabel` formatting conventions to [gist Style Guide](#gistStyleGuide.md).
+- Added section on use of `gist:nonConformingLabel` annotation to `gistStyleGuide.md`.

--- a/docs/release_notes/issue812-geo-predicates
+++ b/docs/release_notes/issue812-geo-predicates
@@ -2,3 +2,7 @@
 
 - Removed `gist:occupiesGeographically` and `gist:occupiesGeographicallyPermanently`, and replaced with `gist:hasPhysicalLocation` in class restriction. Issue [#809](https://github.com/semanticarts/gist/issues/809).
 - Shortened local name of `gist:isGeographicallyContainedin` to `isGeoContainedin`. Issue [#812](https://github.com/semanticarts/gist/issues/812).
+
+### Patch Updates
+
+- Added notes on exceptions to `skos:prefLabel` formatting conventions to [gist Style Guide](#gistStyleGuide.md).

--- a/ontologies/gistCore.ttl
+++ b/ontologies/gistCore.ttl
@@ -1115,7 +1115,7 @@ gist:GeoVolume
 			[
 				a owl:Restriction ;
 				owl:onProperty [
-					owl:inverseOf gist:isGeographicallyContainedIn ;
+					owl:inverseOf gist:isGeoContainedIn ;
 				] ;
 				owl:someValuesFrom gist:GeoPoint ;
 			]
@@ -1294,7 +1294,7 @@ gist:Landmark
 			gist:PhysicalIdentifiableItem
 			[
 				a owl:Restriction ;
-				owl:onProperty gist:occupiesGeographicallyPermanently ;
+				owl:onProperty gist:hasPhysicalLocation ;
 				owl:someValuesFrom [
 					a owl:Class ;
 					owl:unionOf (
@@ -3436,14 +3436,14 @@ gist:isExpressedIn
 	skos:prefLabel "is expressed in"^^xsd:string ;
 	.
 
-gist:isGeographicallyContainedIn
+gist:isGeoContainedIn
 	a
 		owl:ObjectProperty ,
 		owl:TransitiveProperty
 		;
 	rdfs:domain gist:Place ;
 	rdfs:range gist:Place ;
-	skos:definition "Relates one place to another place that contains the first."^^xsd:string ;
+	skos:definition "Relates one place to another that contains it."^^xsd:string ;
 	skos:prefLabel "is geographically contained in"^^xsd:string ;
 	.
 
@@ -3631,29 +3631,6 @@ gist:numericValue
 	] ;
 	skos:definition "The actual value of a magnitude."^^xsd:string ;
 	skos:prefLabel "numeric value"^^xsd:string ;
-	.
-
-gist:occupiesGeographically
-	a owl:ObjectProperty ;
-	rdfs:domain [
-		a owl:Class ;
-		owl:unionOf (
-			gist:PhysicalIdentifiableItem
-			gist:PhysicalSubstance
-		) ;
-	] ;
-	rdfs:range gist:Place ;
-	owl:deprecated "true"^^xsd:boolean ;
-	skos:definition "A thing occupies are region"^^xsd:string ;
-	skos:prefLabel "occupies geographically"^^xsd:string ;
-	.
-
-gist:occupiesGeographicallyPermanently
-	a owl:ObjectProperty ;
-	rdfs:subPropertyOf gist:occupiesGeographically ;
-	owl:deprecated "true"^^xsd:boolean ;
-	skos:definition "To be in a fixed position on the earth"^^xsd:string ;
-	skos:prefLabel "occupies geographically permanently"^^xsd:string ;
 	.
 
 gist:occursIn


### PR DESCRIPTION
Fixes #809 - see https://github.com/semanticarts/gist/issues/947#issuecomment-1679565100
Fixes #812 

NB: I've deliberately kept the full prefLabel "is geographically contained in" for `isGeoContainedIn`. This is a bending of our rule about constructing pref labels, but in this case is warranted, in my opinion. I've updated the style guide to reflect this change.