### PR TITLE
Finalize restrictions on `gist:TimeInterval` and `gist:TemporalRelation`

### DIFF
--- a/docs/release_notes/1046-TimeInterval-TemporalRelation.md
+++ b/docs/release_notes/1046-TimeInterval-TemporalRelation.md
@@ -1,0 +1,5 @@
+### Major Updates
+
+- Removed `gist:endDateTime` restriction from the formal definition of `gist:TemporalRelation`. Issue [#878](https://github.com/semanticarts/gist/issues/878).
+
+- Added `gist:startDateTime`, `gist:endDateTime`, and `gist:Duration` restrictions to the formal definition of `gist:TimeInterval`. Issue [#925](https://github.com/semanticarts/gist/issues/925).

--- a/docs/release_notes/1046-TimeInterval-TemporalRelation.md
+++ b/docs/release_notes/1046-TimeInterval-TemporalRelation.md
@@ -1,5 +1,4 @@
 ### Major Updates
 
 - Removed `gist:endDateTime` restriction from the formal definition of `gist:TemporalRelation`. Issue [#878](https://github.com/semanticarts/gist/issues/878).
-
 - Added `gist:startDateTime`, `gist:endDateTime`, and `gist:Duration` restrictions to the formal definition of `gist:TimeInterval`. Issue [#925](https://github.com/semanticarts/gist/issues/925).

--- a/ontologies/gistCore.ttl
+++ b/ontologies/gistCore.ttl
@@ -2470,11 +2470,6 @@ gist:TemporalRelation
 	rdfs:subClassOf
 		[
 			a owl:Restriction ;
-			owl:onProperty gist:endDateTime ;
-			owl:cardinality "1"^^xsd:nonNegativeInteger ;
-		] ,
-		[
-			a owl:Restriction ;
 			owl:onProperty gist:startDateTime ;
 			owl:cardinality "1"^^xsd:nonNegativeInteger ;
 		] ,
@@ -2517,6 +2512,24 @@ gist:Text
 
 gist:TimeInterval
 	a owl:Class ;
+	rdfs:subClassOf
+		[
+			a owl:Restriction ;
+			owl:onProperty gist:actualEndDateTime ;
+			owl:cardinality "1"^^xsd:nonNegativeInteger ;
+		] ,
+		[
+			a owl:Restriction ;
+			owl:onProperty gist:actualStartDateTime ;
+			owl:cardinality "1"^^xsd:nonNegativeInteger ;
+		] ,
+		[
+			a owl:Restriction ;
+			owl:onProperty gist:hasMagnitude ;
+			owl:onClass gist:Duration ;
+			owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+		]
+		;
 	skos:definition "A span of time with a known start time, end time, and duration. As long as two of the three are known, the third can be inferred."^^xsd:string ;
 	skos:example "7pm to 9pm on Jan 1, 2001; fiscal year 2023; the week starting at midnight of January 12, 2023 and lasting exactly 168 hours."^^xsd:string ;
 	skos:prefLabel "Time Interval"^^xsd:string ;

--- a/ontologies/gistCore.ttl
+++ b/ontologies/gistCore.ttl
@@ -1,5 +1,6 @@
 @prefix : <https://w3id.org/semanticarts/ontology/gistCore#> .
 @prefix gist: <https://w3id.org/semanticarts/ns/ontology/gist/> .
+@prefix gistd: <https://w3id.org/semanticarts/ns/data/gist/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
@@ -2526,7 +2527,17 @@ gist:TimeInterval
 		[
 			a owl:Restriction ;
 			owl:onProperty gist:hasMagnitude ;
-			owl:onClass gist:Duration ;
+			owl:onClass [
+				a owl:Class ;
+				owl:intersectionOf (
+					gist:Magnitude
+					[
+						a owl:Restriction ;
+						owl:onProperty gist:hasAspect ;
+						owl:hasValue gistd:_Aspect_duration ;
+					]
+				) ;
+			] ;
 			owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 		]
 		;


### PR DESCRIPTION
Closes #1046.

This PR reimplements changes originally made in #969 and #970 for v12.1.0. Since they were major changes and v12.1.0 was a minor release, these changes had to be backed out (in #1047).

Note: In #969, I originally listed the removal of the `endDateTime` restriction on `TemporalRelation` as a minor change since the effect on inference was relatively small. I believe that during the v12.1.0 release process we reconsidered and bumped it up to a major change, which is why the change needed to be backed out along with #970.

Original issues:
- #878 
- #925 