### PR TITLE
Build updates

### DIFF
--- a/bundle.yaml
+++ b/bundle.yaml
@@ -115,7 +115,7 @@ actions:
 - action: "sparql"
   message: "Generating rdfs:label and rdfs:comment for backward compatibility."
   source: "{output}/ontologies"
-  target: "{output}/ontologies/rdfsAnnotations.ttl"
+  target: "{output}/ontologies/gistRdfsAnnotations.ttl"
   format: "turtle"
   includes:
     - "*.ttl"

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -205,6 +205,7 @@ actions:
   includes:
     - "ReleaseNotes.md"
     - "MajorVersionMigration.md"
+    - "Namespace.md"
 - action: "copy"
   message: "Copying readme to Documentation directory and patching local links."
   source: "README.md"
@@ -212,13 +213,13 @@ actions:
   replace:
     from: "\\(./(\\w+)\\.md\\)"
     to: "(./\\g<1>.html)"
-- action: "copy"
-  message: "Copying namespace document to Documentation directory and patching local links."
-  source: "{input}/docs/Namespace.md"
-  target: "{output}/Documentation/Namespace.md"
-  replace:
-    from: "\\(./(\\w+)\\.md\\)"
-    to: "(./\\g<1>.html)"
+# - action: "copy"
+#   message: "Copying namespace document to Documentation directory and patching local links."
+#   source: "{input}/docs/Namespace.md"
+#   target: "{output}/Documentation/Namespace.md"
+#   replace:
+#     from: "\\(./(\\w+)\\.md\\)"
+#     to: "(./\\g<1>.html)"
 - action: "copy"
   message: "Copying gist logo to Documentation directory."
   source: "gist-logo.png"

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -213,13 +213,6 @@ actions:
   replace:
     from: "\\(./(\\w+)\\.md\\)"
     to: "(./\\g<1>.html)"
-# - action: "copy"
-#   message: "Copying namespace document to Documentation directory and patching local links."
-#   source: "{input}/docs/Namespace.md"
-#   target: "{output}/Documentation/Namespace.md"
-#   replace:
-#     from: "\\(./(\\w+)\\.md\\)"
-#     to: "(./\\g<1>.html)"
 - action: "copy"
   message: "Copying gist logo to Documentation directory."
   source: "gist-logo.png"

--- a/docs/release_notes/pr1097-build-updates
+++ b/docs/release_notes/pr1097-build-updates
@@ -1,0 +1,6 @@
+### Patch Updates
+
+- Updated build process:
+  - Update to latest version of EDM Council serializer (version 2.0 of rdf-toolkit.jar). Issue [#1082](https://github.com/semanticarts/gist/issues/1082).
+  - Combine two bundle actions into one. Issue [#1058](https://github.com/semanticarts/gist/issues/1058).
+  - Change filename of generated RDFS annotations from `rdfsAnnotations` to `gistRdfsAnnotations`. Issue [#1041](https://github.com/semanticarts/gist/issues/1041).


### PR DESCRIPTION
Closes #1041.
Closes #1058.
Closes #1082.

This PR contains the following changes:
* Change name of generated RDFS annotations file from `rdfsAnnotations` to `gistRdfsAnnotations`.
* Adds latest version of EDM serializer (v. 2).
* Combines two bundle actions together.