### PR TITLE
change prefLabel of altitude from area to altitude

### DIFF
--- a/docs/release_notes/issue1139-altitude-pref-label.md
+++ b/docs/release_notes/issue1139-altitude-pref-label.md
@@ -1,0 +1,1 @@
+Change prefLabel of altitude from "area" to "altitude".

--- a/ontologies/gistCore.ttl
+++ b/ontologies/gistCore.ttl
@@ -44,7 +44,7 @@ gistd:_Aspect_altitude
 	a gist:Aspect ;
 	skos:definition "The aspect altitude."^^xsd:string ;
 	skos:editorialNote "This instance has been duplicated from reference data so it can be used in property restrictions."^^xsd:string ;
-	skos:prefLabel "area"^^xsd:string ;
+	skos:prefLabel "altitude"^^xsd:string ;
 	.
 
 gistd:_Aspect_area


### PR DESCRIPTION
closes #1139 

copy-paste error resulted in altitude having prefLabel "area"

changed prefLabel to "altitude"