### PR TITLE
Issue #1155 Annotations conform to style guide

### DIFF
--- a/ontologies/gistCore.ttl
+++ b/ontologies/gistCore.ttl
@@ -1471,7 +1471,7 @@ gist:Person
 gist:PhysicalActionType
 	a owl:Class ;
 	rdfs:subClassOf gist:Category ;
-	skos:definition "A category indicating the type of an action in terms of its effect in the physical world."^^xsd:string ;
+	skos:definition "A category indicating the type of an action based on its effect in the physical world."^^xsd:string ;
 	skos:example "Lifting a garage door, turning off a valve, dropping cadmium rods."^^xsd:string ;
 	skos:prefLabel "Physical Action Type"^^xsd:string ;
 	.


### PR DESCRIPTION
This set of changes focuses on removing excess information from `skos:definition` and moving it to `skos:example` or `skos:scopeNote`. There is also some reformatting of all three annotations. However these changes do not attempt to make `skos:definition` full sentences where they are not. More changes will be added for this.

The definitions most significantly affected by removing examples are `gist:Behavior` and `gist:Content`. `gist:Behavior` maybe falls in the category "Occasionally a definition can hardly be understood at all without an example" of the style guide. My recommendation is that we try to make a more specific, full sentence definition, but we may determine that it is most clear to simply add the example back to the definition.

Our definition of `gist:Content`, in my opinion, was not a definition but rather a list of examples. I attempted to make a new definition, but would appreciate input on if this matches the existing usage. If there is other history on this definition and why we should include examples in the definition, that would also be helpful.

Closes #1155 