### PR TITLE
Added spec entry class

### DIFF
--- a/ontologies/gistCore.ttl
+++ b/ontologies/gistCore.ttl
@@ -1751,11 +1751,15 @@ gist:SpecEntry
 		) ;
 	] ;
 	skos:definition "A specification of a set of acceptable values for a particular aspect indicating what it means to be in spec for that aspect."^^xsd:string ;
-	skos:example "The aspect width must be greater or equal to 4 inches and less than 10 inches. In this case there would be two triples linking the Spec Entry to values using subproperties of specifiedValue - one for expressing greater or equal to 4 inches and one for expressing less than 10 inches."^^xsd:string ;
+	skos:example
+		"The aspect width must be greater or equal to 4 inches and less than 10 inches. In this case there would be two triples linking the spec entry to values using subproperties of specifiedValue - one for expressing greater or equal to 4 inches and one for expressing less than 10 inches."^^xsd:string ,
+		"The specification for a smartphone model might have three spec entries, one for weight (= 15 oz), one for color (red or blue) and one for battery life (between 12 & 14 hours)."^^xsd:string
+		;
 	skos:prefLabel "Spec Entry"^^xsd:string ;
 	skos:scopeNote
+		"An individual spec entry will typically be one of several that makes up an overall specification of something with various aspects."^^xsd:string ,
 		"In addition to ordinary numerical scales, sets of acceptable values may also come from nominal or ordinal scales of measure."^^xsd:string ,
-		"Often this will be about what is required, allowed or promised, but it could also be used to specify what is disallowed."^^xsd:string
+		"Often a spec entry will specify what is required, allowed or promised, but it could also be used to specify what is disallowed."^^xsd:string
 		;
 	.
 

--- a/ontologies/gistCore.ttl
+++ b/ontologies/gistCore.ttl
@@ -2883,6 +2883,14 @@ gist:hasUnitOfMeasure
 	skos:prefLabel "has unit of measure"^^xsd:string ;
 	.
 
+gist:hasValueEqualToOneOf
+	a owl:ObjectProperty ;
+	rdfs:subPropertyOf ops:hasSpecifiedValue ;
+	skos:definition "Relates a specification to a collection of values, one of which a characteristic must be equal to."^^xsd:string ;
+	skos:example "The color of something must be blue or red."^^xsd:string ;
+	skos:prefLabel "has value equal to one of"^^xsd:string ;
+	.
+
 gist:idText
 	a owl:DatatypeProperty ;
 	rdfs:range xsd:string ;

--- a/ontologies/gistCore.ttl
+++ b/ontologies/gistCore.ttl
@@ -1751,7 +1751,7 @@ gist:SpecEntry
 		) ;
 	] ;
 	skos:definition "A specification of a set of acceptable values for a particular aspect indicating what it means to be in spec for that aspect."^^xsd:string ;
-	skos:example "The aspect, width must be greater or equal to 4 inches and less than 10 inches. In this case there would be two triples linking the Spec Entry to values using subproperties of specifiedValue - one for expressing greater or equal to 4 inches and one for expressing less than 10 inches."^^xsd:string ;
+	skos:example "The aspect width must be greater or equal to 4 inches and less than 10 inches. In this case there would be two triples linking the Spec Entry to values using subproperties of specifiedValue - one for expressing greater or equal to 4 inches and one for expressing less than 10 inches."^^xsd:string ;
 	skos:prefLabel "Spec Entry"^^xsd:string ;
 	skos:scopeNote
 		"In addition to ordinary numerical scales, sets of acceptable values may also come from nominal or ordinal scales of measure."^^xsd:string ,

--- a/ontologies/gistCore.ttl
+++ b/ontologies/gistCore.ttl
@@ -2887,8 +2887,10 @@ gist:hasValueEqualToOneOf
 	a owl:ObjectProperty ;
 	rdfs:subPropertyOf ops:hasSpecifiedValue ;
 	skos:definition "Relates a specification to a collection of values, one of which a characteristic must be equal to."^^xsd:string ;
+	skos:editorialNote "If this operator is added to the operators ontology in the future, update gist core to use the ops namespace instead of gist for the hasValueEqualToOneOf property."^^xsd:string ;
 	skos:example "The color of something must be blue or red."^^xsd:string ;
 	skos:prefLabel "has value equal to one of"^^xsd:string ;
+	skos:scopeNote "This adds to the set of operators defined in the imported operators ontology."^^xsd:string ;
 	.
 
 gist:idText

--- a/ontologies/gistCore.ttl
+++ b/ontologies/gistCore.ttl
@@ -1,5 +1,8 @@
+# imports: https://w3id.org/semanticarts/ontology/operators1.0.0
+
 @prefix gist: <https://w3id.org/semanticarts/ns/ontology/gist/> .
 @prefix gistd: <https://w3id.org/semanticarts/ns/data/gist/> .
+@prefix ops: <https://w3id.org/semanticarts/ns/ontology/operators/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
@@ -10,6 +13,7 @@
 
 <https://w3id.org/semanticarts/ontology/gistCore>
 	a owl:Ontology ;
+	owl:imports <https://w3id.org/semanticarts/ontology/operators1.0.0> ;
 	owl:versionIRI <https://w3id.org/semanticarts/ontology/gistCoreX.x.x> ;
 	skos:definition "gist is a minimalist upper ontology created by Semantic Arts."^^xsd:string ;
 	skos:historyNote """
@@ -1719,6 +1723,40 @@ gist:ServiceSpecification
 	] ;
 	skos:definition "A description of something that can be done for a person or organization (which produces some form of an act)."^^xsd:string ;
 	skos:prefLabel "Service Specification"^^xsd:string ;
+	.
+
+gist:SpecEntry
+	a owl:Class ;
+	rdfs:seeAlso <https://github.com/semanticarts/operators-ontology> ;
+	owl:equivalentClass [
+		a owl:Class ;
+		owl:intersectionOf (
+			gist:Specification
+			[
+				a owl:Restriction ;
+				owl:onProperty gist:hasAspect ;
+				owl:someValuesFrom gist:Aspect ;
+			]
+			[
+				a owl:Restriction ;
+				owl:onProperty ops:hasSpecifiedValue ;
+				owl:someValuesFrom [
+					a owl:Class ;
+					owl:unionOf (
+						gist:Category
+						gist:Magnitude
+					) ;
+				] ;
+			]
+		) ;
+	] ;
+	skos:definition "A specification of a set of acceptable values for a particular aspect indicating what it means to be in spec for that aspect."^^xsd:string ;
+	skos:example "The aspect, width must be greater or equal to 4 inches and less than 10 inches. In this case there would be two triples linking the Spec Entry to values using subproperties of specifiedValue - one for expressing greater or equal to 4 inches and one for expressing less than 10 inches."^^xsd:string ;
+	skos:prefLabel "Spec Entry"^^xsd:string ;
+	skos:scopeNote
+		"In addition to ordinary numerical scales, sets of acceptable values may also come from nominal or ordinal scales of measure."^^xsd:string ,
+		"Often this will be about what is required, allowed or promised, but it could also be used to specify what is not allowed."^^xsd:string
+		;
 	.
 
 gist:Specification

--- a/ontologies/gistCore.ttl
+++ b/ontologies/gistCore.ttl
@@ -1755,7 +1755,7 @@ gist:SpecEntry
 	skos:prefLabel "Spec Entry"^^xsd:string ;
 	skos:scopeNote
 		"In addition to ordinary numerical scales, sets of acceptable values may also come from nominal or ordinal scales of measure."^^xsd:string ,
-		"Often this will be about what is required, allowed or promised, but it could also be used to specify what is not allowed."^^xsd:string
+		"Often this will be about what is required, allowed or promised, but it could also be used to specify what is disallowed."^^xsd:string
 		;
 	.
 


### PR DESCRIPTION
Closes #527.

INTENDED AS DRAFT FOR DISCUSSION

Added `SpecEntry` class, by importing the operators ontology.  Below is an example usage that uses some gist units reference data. Note how the possible values for aspects that are not magnitudes are specified by pointing to a collection. This allows different combinations of colors to be used in different  contexts (e.g. warm colors vs. cool colors) w/o needing new category classes. 

![examplesProductSpec](https://github.com/user-attachments/assets/8fcd667a-5fd0-43cf-b821-2b4c00764ffa)



If we want to use `gist:isPartOf`, the diagram gets a bit ugly.



![examplesProductSpec-UglyLayout](https://github.com/user-attachments/assets/28f0d044-6c02-41be-8e32-b14a5517dc29)

