### PR TITLE
fix geo route and remove geo segment

### DIFF
--- a/docs/release_notes/issue1165-remove-geosegment.md
+++ b/docs/release_notes/issue1165-remove-geosegment.md
@@ -1,0 +1,1 @@
+Change the class equivalence statement for GeoRoute to say it is an ordered collection whose members are geo points. Also, GeoSegment is not necessary because it is just a geo route with two geo points. Therefore the class GeoSegment is being removed from gist.

--- a/docs/release_notes/issue1165-remove-geosegment.md
+++ b/docs/release_notes/issue1165-remove-geosegment.md
@@ -1,1 +1,7 @@
-Change the class equivalence statement for GeoRoute to say it is an ordered collection whose members are geo points. Also, GeoSegment is not necessary because it is just a geo route with two geo points. Therefore the class GeoSegment is being removed from gist.
+### Minor Updates
+
+- Deprecate `gist:GeoSegment`. Issue [#1165](https://github.com/semanticarts/gist/issues/1165).
+
+### Patch Updates
+
+- Correct errors in property restriction on `gist:GeoRoute`. Issue [#1165](https://github.com/semanticarts/gist/issues/1165).

--- a/ontologies/gistCore.ttl
+++ b/ontologies/gistCore.ttl
@@ -802,7 +802,7 @@ gist:GeoSegment
 		) ;
 	] ;
 	skos:definition "A single portion of a GeoRoute consisting of a pair of consecutive GeoPoints which belong to it."^^xsd:string ;
-	skos:editorialNote "See guidance on removing this term in the next major release at #1181."^^xsd:string ;
+	skos:editorialNote "See guidance on removing this term in the next major release at #1182."^^xsd:string ;
 	skos:prefLabel "Geo Segment"^^xsd:string ;
 	skos:scopeNote "A GeoSegment is also a GeoRoute (a short one)."^^xsd:string ;
 	.

--- a/ontologies/gistCore.ttl
+++ b/ontologies/gistCore.ttl
@@ -770,15 +770,14 @@ gist:GeoRoute
 			[
 				a owl:Restriction ;
 				owl:onProperty [
-					owl:inverseOf gist:isDirectPartOf ;
+					owl:inverseOf gist:isMemberOf ;
 				] ;
-				owl:someValuesFrom gist:GeoSegment ;
+				owl:someValuesFrom gist:GeoPoint ;
 			]
 		) ;
 	] ;
-	skos:definition "An ordered set of GeoPoints that defines a path from starting point to ending point."^^xsd:string ;
+	skos:definition "An ordered set of GeoPoints that defines a path from a starting point to an ending point."^^xsd:string ;
 	skos:prefLabel "Geo Route"^^xsd:string ;
-	skos:scopeNote "Each pair of consecutive GeoPoints in a GeoRoute is a GeoSegment."^^xsd:string ;
 	.
 
 gist:GeoVolume

--- a/ontologies/gistCore.ttl
+++ b/ontologies/gistCore.ttl
@@ -780,6 +780,33 @@ gist:GeoRoute
 	skos:prefLabel "Geo Route"^^xsd:string ;
 	.
 
+gist:GeoSegment
+	a owl:Class ;
+	rdfs:subClassOf gist:Place ;
+	owl:deprecated "true"^^xsd:boolean ;
+	owl:equivalentClass [
+		a owl:Class ;
+		owl:intersectionOf (
+			[
+				a owl:Restriction ;
+				owl:onProperty gist:comesFromPlace ;
+				owl:onClass gist:GeoPoint ;
+				owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+			]
+			[
+				a owl:Restriction ;
+				owl:onProperty gist:goesToPlace ;
+				owl:onClass gist:GeoPoint ;
+				owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+			]
+		) ;
+	] ;
+	skos:definition "A single portion of a GeoRoute consisting of a pair of consecutive GeoPoints which belong to it."^^xsd:string ;
+	skos:editorialNote "See guidance on removing this term in the next major release at #1181."^^xsd:string ;
+	skos:prefLabel "Geo Segment"^^xsd:string ;
+	skos:scopeNote "A GeoSegment is also a GeoRoute (a short one)."^^xsd:string ;
+	.
+
 gist:GeoVolume
 	a owl:Class ;
 	rdfs:subClassOf gist:Place ;

--- a/ontologies/gistCore.ttl
+++ b/ontologies/gistCore.ttl
@@ -781,31 +781,6 @@ gist:GeoRoute
 	skos:scopeNote "Each pair of consecutive GeoPoints in a GeoRoute is a GeoSegment."^^xsd:string ;
 	.
 
-gist:GeoSegment
-	a owl:Class ;
-	rdfs:subClassOf gist:Place ;
-	owl:equivalentClass [
-		a owl:Class ;
-		owl:intersectionOf (
-			[
-				a owl:Restriction ;
-				owl:onProperty gist:comesFromPlace ;
-				owl:onClass gist:GeoPoint ;
-				owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
-			]
-			[
-				a owl:Restriction ;
-				owl:onProperty gist:goesToPlace ;
-				owl:onClass gist:GeoPoint ;
-				owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
-			]
-		) ;
-	] ;
-	skos:definition "A single portion of a GeoRoute consisting of a pair of consecutive GeoPoints which belong to it."^^xsd:string ;
-	skos:prefLabel "Geo Segment"^^xsd:string ;
-	skos:scopeNote "A GeoSegment is also a GeoRoute (a short one)."^^xsd:string ;
-	.
-
 gist:GeoVolume
 	a owl:Class ;
 	rdfs:subClassOf gist:Place ;


### PR DESCRIPTION
Remove GeoSegment, change GeoRoute class equivalence to say it is an ordered collection whose members are GeoPoints (old class equivalence incorrectly said it was an ordered collection with GeoSegments as parts).
Closes #1165 