### PR TITLE
Issue 1186: Make gist:Text a subclass of gist:ContentExpression

### DIFF
--- a/docs/release_notes/issue1186-subclasses-of-gistcontentexpression.md
+++ b/docs/release_notes/issue1186-subclasses-of-gistcontentexpression.md
@@ -1,0 +1,3 @@
+# Major Updates
+
+- Changed `gist:Text` to be a subclass of `gist:ContentExpression` rather than `gist:Content`. Issue [1186](https://github.com/semanticarts/gist/issues/1186).

--- a/ontologies/gistCore.ttl
+++ b/ontologies/gistCore.ttl
@@ -1968,7 +1968,7 @@ gist:Text
 	owl:equivalentClass [
 		a owl:Class ;
 		owl:intersectionOf (
-			gist:Content
+			gist:ContentExpression
 			[
 				a owl:Restriction ;
 				owl:onProperty gist:isExpressedIn ;


### PR DESCRIPTION
Closes #1186
- Changed `gist:Text` to be a subclass of `gist:ContentExpression` rather than `gist:Content`.