### PR TITLE
Add disjointness axioms to `gist:Event`

### DIFF
--- a/ontologies/gistCore.ttl
+++ b/ontologies/gistCore.ttl
@@ -653,6 +653,15 @@ gist:EquipmentType
 
 gist:Event
 	a owl:Class ;
+	owl:disjointWith
+		gist:Aspect ,
+		gist:Category ,
+		gist:Language ,
+		gist:Magnitude ,
+		gist:SchemaMetaData ,
+		gist:TimeInterval ,
+		gist:UnitOfMeasure
+		;
 	skos:definition "Something that occurs over a period of time, often characterized as an activity being carried out by some person, organization, or software application or brought about by natural forces."^^xsd:string ;
 	skos:editorialNote "See guidance on removing the term in the next major release at https://github.com/semanticarts/gist/issues/947#issuecomment-1679565100."^^xsd:string ;
 	skos:example "A transaction, conference, baseball game, earthquake."^^xsd:string ;


### PR DESCRIPTION
Closes #1212. I have just posted there detailing the rationale. In short, for now I've added axioms for top-level classes that I think are uncontroversially disjoint with `gist:Event`. For the remaining top-level classes, I believe gist can remain neutral.