### PR TITLE
Stevenchalem/1272 fix broken links in contributingmd GitHub rendering

### DIFF
--- a/docs/Contributing.md
+++ b/docs/Contributing.md
@@ -84,7 +84,7 @@ When you make a commit, the pre-commit hook:
 
 ### Style Guide
 
-- Ontologists should consult the emerging [_gist Style Guide_](./gistStyleGuide.md) during implementation.
+- Ontologists should consult the [_gist Style Guide_](./gistStyleGuide.md) during implementation.
 
 ### Commits, Pushes, and Merges
 


### PR DESCRIPTION
Fixes some links in Contributing.md that were not working correctly when the file is rendered on GitHub
Closes #1272 