### PR TITLE
Refactor pre-commit hook

### DIFF
--- a/docs/release_notes/891-refactor-pre-commit
+++ b/docs/release_notes/891-refactor-pre-commit
@@ -1,6 +1,6 @@
 ### Patch Updates
 
-- Refactored the git pre-commit to make sure the latest version is always used.
+- Refactored the git pre-commit to make sure the latest version is always used. Issue [#891](https://github.com/semanticarts/gist/issues/891)
   - Updated setup.cmd to install tools/pre-commit-hook as .git/hooks/pre-commit
   - New file tools/pre-commit-hook which just calls ./tools/pre-commit-code.
   - Renamed tools/pre-commit to tools/pre-commit-code

--- a/docs/release_notes/891-refactor-pre-commit
+++ b/docs/release_notes/891-refactor-pre-commit
@@ -1,0 +1,7 @@
+### Patch Updates
+
+- Refactored the git pre-commit to make sure the latest version is always used.
+  - Updated setup.cmd to install tools/pre-commit-hook as .git/hooks/pre-commit
+  - New file tools/pre-commit-hook which just calls ./tools/pre-commit-code.
+  - Renamed tools/pre-commit to tools/pre-commit-code
+

--- a/tools/pre-commit-code
+++ b/tools/pre-commit-code
@@ -1,6 +1,7 @@
 #!/usr/bin/env sh
 
-# This file should be copied into the .git/hooks directory of the project.
+# This file performs all the actual git pre-commit checks.
+# It should be called by .git/hooks/pre-commit, which should be a copy of tools/pre-commit-hook.
 
 # Stops accidental commits to branches master, main, or develop.
 BRANCH=`git rev-parse --abbrev-ref HEAD`

--- a/tools/pre-commit-hook
+++ b/tools/pre-commit-hook
@@ -1,0 +1,18 @@
+#!/usr/bin/env sh
+
+# This file should be copied into the .git/hooks directory of the project.
+# All it does is call ./tools/pre-commit-code
+
+# Get root directory of this git repository
+base_dir=$(git rev-parse --show-toplevel)
+
+# Run the pre-commit code from the ./tools/ directory
+"${base_dir}/tools/pre-commit-code"
+rc=$?
+
+# Return the response code from previous command
+if [ ! ${rc} -eq 0 ] ; then
+  exit 1
+fi
+
+exit 0

--- a/tools/setup.cmd
+++ b/tools/setup.cmd
@@ -16,11 +16,14 @@ base_dir=$(git rev-parse --show-toplevel)
 # Print out commands so user can see what is being done
 set -x
 
-# Copy pre-commit to the git hooks directory
-cp "${base_dir}/tools/pre-commit" "${base_dir}/.git/hooks/"
+# Copy pre-commit-hook to the git hooks directory
+cp "${base_dir}/tools/pre-commit-hook" "${base_dir}/.git/hooks/pre-commit"
 
 # Make pre-commit hook executable.
 chmod +x "${base_dir}/.git/hooks/pre-commit"
+
+# Ensure that tools/pre-commit-code is executable.
+chmod +x "${base_dir}/tools/pre-commit-code"
 
 # Ensure that the serializer pre-commit hook is executable.
 chmod +x "${base_dir}/tools/serializer/pre-commit"
@@ -38,8 +41,8 @@ exit
 :WINDOWS
 CHDIR "%~dp0"
 IF EXIST "tools" chdir tools
-IF EXIST "pre-commit" (
-  copy "pre-commit" ..\.git\hooks\
+IF EXIST "pre-commit-hook" (
+  copy "pre-commit-hook" ..\.git\hooks\pre-commit
 ) ELSE (
-  echo Could not find the "pre-commit" file in %cd%.
+  echo ERROR: Could not find the "pre-commit-hook" file in %cd%.
 )


### PR DESCRIPTION
Closes #891

This branch is stacked on the #1304 branch.

This moves all of the pre-commit logic into a separate file which is called by the new pre-commit hook.
This means that changes in the pre-commit-code file will automatically be used in the future as we make changes.

I think this is a better solution than the one I originally proposed, which checked if there was an update and told the user to re-run setup.cmd.
