### PR TITLE
Modified materialize_subclass_inferences.py to work under Windows

### DIFF
--- a/tools/subclass_inferences/materialize_subclass_inferences.py
+++ b/tools/subclass_inferences/materialize_subclass_inferences.py
@@ -56,9 +56,10 @@ def _run_reasoner(inputs: list[str], output_ttl: str, version: str):
         input_graph.parse(one_input)
 
     # owlready2 does not accept TTL files. Convert to N-Triples.
-    with tempfile.NamedTemporaryFile('w', suffix='.nt', delete=False) as temp_file:
+    with tempfile.NamedTemporaryFile('wb', suffix='.nt', delete=False) as temp_file:
         input_graph_str = input_graph.serialize(format='nt')
-        temp_file.write(input_graph_str)
+        temp_file.write(input_graph_str if isinstance(input_graph_str, bytes)
+                        else input_graph_str.encode('utf-8'))
         temp_file.flush()
         temp_file.close()
 


### PR DESCRIPTION
Changes to the creation of the temporary n-triples file to avoid file-locking and file-format errors when running under Windows.

Closes #1315 
Closes #1316 

