### PR TITLE
Fix 'skos:example:' predicate

### DIFF
--- a/docs/release_notes/issue1333-fix-skos-example
+++ b/docs/release_notes/issue1333-fix-skos-example
@@ -1,4 +1,0 @@
-### Patch Updates
-
-- Fixed typo in `skos:example`.
-


### PR DESCRIPTION
Closes #1333 

Fixes typo in `skos:example:`.

It seems to be valid Turtle, but creates an invalid rdf/xml file, which is what is downloaded when you download the ontology IRI.

I hand edited the file on the web server so that it would be valid. But the version in the download zip file is still bad.