### PR TITLE
Serialization and HTML subdirectories when bundling

### DIFF
--- a/bundle.yaml
+++ b/bundle.yaml
@@ -267,7 +267,7 @@ actions:
 - action: "move"
   message: "Patching local links in gist 11.0 HTML migration documentation."
   source: "{output}/migration/v11.0/"
-  target: "{output}/migration/v11.0/html/"
+  target: "{output}/migration/v11.0/html-doc/"
   includes:
     - "*.html"
   # Replace .md with .html in local links of HTML files
@@ -276,7 +276,7 @@ actions:
     to: "\\g<1>.html"
 - action: "move"
   source: "{output}/migration/v11.0/"
-  target: "{output}/migration/v11.0/markdown/"
+  target: "{output}/migration/v11.0/markdown-doc/"
   includes:
     - "*.md"
 - action: "markdown"
@@ -288,7 +288,7 @@ actions:
 - action: "move"
   message: "Patching local links in gist 12.0 HTML migration documentation."
   source: "{output}/migration/v12.0/"
-  target: "{output}/migration/v12.0/html/"
+  target: "{output}/migration/v12.0/html-doc/"
   includes:
     - "*.html"
   # Replace .md with .html in local links of HTML files
@@ -297,7 +297,7 @@ actions:
     to: "\\g<1>.html"
 - action: "move"
   source: "{output}/migration/v12.0/"
-  target: "{output}/migration/v12.0/markdown/"
+  target: "{output}/migration/v12.0/markdown-doc/"
   includes:
     - "*.md"
 - action: "markdown"
@@ -309,7 +309,7 @@ actions:
 - action: "move"
   message: "Patching links in gist 13.0 HTML migration documentation."
   source: "{output}/migration/v13.0/"
-  target: "{output}/migration/v13.0/html/"
+  target: "{output}/migration/v13.0/html-doc/"
   includes:
     - "*.html"
   # Replace .md with .html in local links of HTML files
@@ -318,7 +318,7 @@ actions:
     to: "\\g<1>.html"
 - action: "move"
   source: "{output}/migration/v13.0/"
-  target: "{output}/migration/v13.0/markdown/"
+  target: "{output}/migration/v13.0/markdown-doc/"
   includes:
     - "*.md"
 - action: "markdown"
@@ -330,12 +330,12 @@ actions:
 - action: "move"
   message: "Patching links in gist 14.0 HTML migration documentation."
   source: "{output}/migration/v14.0/"
-  target: "{output}/migration/v14.0/html/"
+  target: "{output}/migration/v14.0/html-doc/"
   includes:
     - "*.html"
 - action: "move"
   source: "{output}/migration/v14.0/"
-  target: "{output}/migration/v14.0/markdown/"
+  target: "{output}/migration/v14.0/markdown-doc/"
   includes:
     - "*.md"
   # Replace .md with .html in local links of HTML files

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -119,8 +119,6 @@ actions:
   format: "turtle"
   includes:
     - "*.ttl"
-  excludes:
-    - gistValidationAnnotations.ttl
   query: >
     prefix gist: <https://w3id.org/semanticarts/ns/ontology/gist/>
     prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>
@@ -167,11 +165,16 @@ actions:
   rename:
     from: "formatted_(.*)\\.ttl"
     to: "\\g<1>.ttl"
+- action: "move"
+  source: "{output}/ontologies/"
+  target: "{output}/ontologies/turtle/"
+  includes:
+    - "*.ttl"
 - action: "transform"
   message: "RDF/XML serialization."
   tool: "xml-serializer"
-  source: "{output}/ontologies"
-  target: "{output}/ontologies"
+  source: "{output}/ontologies/turtle/"
+  target: "{output}/ontologies/rdf-xml/"
   rename:
     from: "(.*)\\.ttl"
     to: "\\g<1>.rdf"
@@ -180,8 +183,8 @@ actions:
 - action: "transform"
   message: "JSON-LD serialization."
   tool: "json-serializer"
-  source: "{output}/ontologies"
-  target: "{output}/ontologies"
+  source: "{output}/ontologies/turtle/"
+  target: "{output}/ontologies/json-ld/"
   rename:
     from: "(.*)\\.ttl"
     to: "\\g<1>.jsonld"
@@ -215,7 +218,7 @@ actions:
 - action: "move"
   message: "Patching local links in documentation."
   source: "{output}/docs/"
-  target: "{output}/docs/"
+  target: "{output}/docs/HTML/"
   includes:
     - "*.html"
   # Replace .md with .html in local links of HTML files.
@@ -237,7 +240,7 @@ actions:
 - action: "move"
   message: "Patching local links in HTML model documentation."
   source: "{output}/docs/models/"
-  target: "{output}/docs/models/"
+  target: "{output}/docs/models/HTML/"
   includes:
     - "*.html"
   # Replace .md with .html in local links of HTML files
@@ -257,7 +260,7 @@ actions:
 - action: "move"
   message: "Patching local links in gist 11.0 HTML migration documentation."
   source: "{output}/migration/v11.0/"
-  target: "{output}/migration/v11.0/"
+  target: "{output}/migration/v11.0/HTML/"
   includes:
     - "*.html"
   # Replace .md with .html in local links of HTML files
@@ -273,7 +276,7 @@ actions:
 - action: "move"
   message: "Patching local links in gist 12.0 HTML migration documentation."
   source: "{output}/migration/v12.0/"
-  target: "{output}/migration/v12.0/"
+  target: "{output}/migration/v12.0/HTML/"
   includes:
     - "*.html"
   # Replace .md with .html in local links of HTML files
@@ -289,7 +292,7 @@ actions:
 - action: "move"
   message: "Patching links in gist 13.0 HTML migration documentation."
   source: "{output}/migration/v13.0/"
-  target: "{output}/migration/v13.0/"
+  target: "{output}/migration/v13.0/HTML/"
   includes:
     - "*.html"
   # Replace .md with .html in local links of HTML files
@@ -305,7 +308,7 @@ actions:
 - action: "move"
   message: "Patching links in gist 14.0 HTML migration documentation."
   source: "{output}/migration/v14.0/"
-  target: "{output}/migration/v14.0/"
+  target: "{output}/migration/v14.0/HTML/"
   includes:
     - "*.html"
   # Replace .md with .html in local links of HTML files

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -218,7 +218,7 @@ actions:
 - action: "move"
   message: "Patching local links in documentation."
   source: "{output}/docs/"
-  target: "{output}/docs/HTML/"
+  target: "{output}/docs/html/"
   includes:
     - "*.html"
   # Replace .md with .html in local links of HTML files.
@@ -227,20 +227,27 @@ actions:
   replace:
     from: "((\\./|(?:\\.\\./)+).+)\\.md"
     to: "\\g<1>.html"
+- action: "move"
+  source: "{output}/docs/"
+  target: "{output}/docs/markdown/"
+  includes:
+    - "*.md"
 - action: "copy"
   message: "Copying model documentation."
-  source: "{input}/docs/models"
-  target: "{output}/docs/models"
+  source: "{input}/docs/models/"
+  target: "{output}/docs/markdown/models/"
+  includes:
+    - "*.md"
 - action: "markdown"
   message: "Formatting model documentation as HTML."
-  source: "{output}/docs/models/"
-  target: "{output}/docs/models/"
+  source: "{output}/docs/markdown/models/"
+  target: "{output}/docs/markdown/models/"
   includes:
     - "*.md"
 - action: "move"
   message: "Patching local links in HTML model documentation."
-  source: "{output}/docs/models/"
-  target: "{output}/docs/models/HTML/"
+  source: "{output}/docs/markdown/models/"
+  target: "{output}/docs/html/models/"
   includes:
     - "*.html"
   # Replace .md with .html in local links of HTML files
@@ -260,13 +267,18 @@ actions:
 - action: "move"
   message: "Patching local links in gist 11.0 HTML migration documentation."
   source: "{output}/migration/v11.0/"
-  target: "{output}/migration/v11.0/HTML/"
+  target: "{output}/migration/v11.0/html/"
   includes:
     - "*.html"
   # Replace .md with .html in local links of HTML files
   replace:
     from: "((\\./|(?:\\.\\./)+).+)\\.md"
     to: "\\g<1>.html"
+- action: "move"
+  source: "{output}/migration/v11.0/"
+  target: "{output}/migration/v11.0/markdown/"
+  includes:
+    - "*.md"
 - action: "markdown"
   message: "Formatting gist 12.0 migration documentation as HTML."
   source: "{output}/migration/v12.0/"
@@ -276,13 +288,18 @@ actions:
 - action: "move"
   message: "Patching local links in gist 12.0 HTML migration documentation."
   source: "{output}/migration/v12.0/"
-  target: "{output}/migration/v12.0/HTML/"
+  target: "{output}/migration/v12.0/html/"
   includes:
     - "*.html"
   # Replace .md with .html in local links of HTML files
   replace:
     from: "((\\./|(?:\\.\\./)+).+)\\.md"
     to: "\\g<1>.html"
+- action: "move"
+  source: "{output}/migration/v12.0/"
+  target: "{output}/migration/v12.0/markdown/"
+  includes:
+    - "*.md"
 - action: "markdown"
   message: "Formatting gist 13.0 migration documentation as HTML."
   source: "{output}/migration/v13.0/"
@@ -292,13 +309,18 @@ actions:
 - action: "move"
   message: "Patching links in gist 13.0 HTML migration documentation."
   source: "{output}/migration/v13.0/"
-  target: "{output}/migration/v13.0/HTML/"
+  target: "{output}/migration/v13.0/html/"
   includes:
     - "*.html"
   # Replace .md with .html in local links of HTML files
   replace:
     from: "((\\./|(?:\\.\\./)+).+)\\.md"
     to: "\\g<1>.html"
+- action: "move"
+  source: "{output}/migration/v13.0/"
+  target: "{output}/migration/v13.0/markdown/"
+  includes:
+    - "*.md"
 - action: "markdown"
   message: "Formatting gist 14.0 migration documentation as HTML."
   source: "{output}/migration/v14.0/"
@@ -308,9 +330,14 @@ actions:
 - action: "move"
   message: "Patching links in gist 14.0 HTML migration documentation."
   source: "{output}/migration/v14.0/"
-  target: "{output}/migration/v14.0/HTML/"
+  target: "{output}/migration/v14.0/html/"
   includes:
     - "*.html"
+- action: "move"
+  source: "{output}/migration/v14.0/"
+  target: "{output}/migration/v14.0/markdown/"
+  includes:
+    - "*.md"
   # Replace .md with .html in local links of HTML files
   replace:
     from: "((\\./|(?:\\.\\./)+).+)\\.md"

--- a/docs/release_notes/1347_release_notes.md
+++ b/docs/release_notes/1347_release_notes.md
@@ -1,3 +1,3 @@
 ### Patch Updates
 
-- Added format-specific directory creation for ontology and documentation files to `bundle.yaml`. Issue [#1347](https://github.com/semanticarts/gist/issues/1347).
+- Updated the bundling process to split ontology and documentation files into format-specific directories in the release package. Issue [#1347](https://github.com/semanticarts/gist/issues/1347).

--- a/docs/release_notes/1347_release_notes.md
+++ b/docs/release_notes/1347_release_notes.md
@@ -1,4 +1,3 @@
 ### Patch Updates
 
 - Added format-specific directory creation for ontology and documentation files to `bundle.yaml`. Issue [#1347](https://github.com/semanticarts/gist/issues/1347).
-- Updated `bundle.yaml` to create `markdown` and `html` directories. Issue [#1347](https://github.com/semanticarts/gist/issues/1347).

--- a/docs/release_notes/1347_release_notes.md
+++ b/docs/release_notes/1347_release_notes.md
@@ -1,0 +1,4 @@
+### Patch Updates
+
+- Added serialization specific directory creation to `bundle.yaml`. Issue [#1347](https://github.com/semanticarts/gist/issues/1347).
+- Updated `bundle.yaml` to create `HTML` directories. Issue [#1347](https://github.com/semanticarts/gist/issues/1347).

--- a/docs/release_notes/1347_release_notes.md
+++ b/docs/release_notes/1347_release_notes.md
@@ -1,4 +1,4 @@
 ### Patch Updates
 
 - Added serialization specific directory creation to `bundle.yaml`. Issue [#1347](https://github.com/semanticarts/gist/issues/1347).
-- Updated `bundle.yaml` to create `HTML` directories. Issue [#1347](https://github.com/semanticarts/gist/issues/1347).
+- Updated `bundle.yaml` to create `markdown` and `html` directories. Issue [#1347](https://github.com/semanticarts/gist/issues/1347).

--- a/docs/release_notes/1347_release_notes.md
+++ b/docs/release_notes/1347_release_notes.md
@@ -1,4 +1,4 @@
 ### Patch Updates
 
-- Added serialization specific directory creation to `bundle.yaml`. Issue [#1347](https://github.com/semanticarts/gist/issues/1347).
+- Added format-specific directory creation for ontology and documentation files to `bundle.yaml`. Issue [#1347](https://github.com/semanticarts/gist/issues/1347).
 - Updated `bundle.yaml` to create `markdown` and `html` directories. Issue [#1347](https://github.com/semanticarts/gist/issues/1347).


### PR DESCRIPTION
Closes #1347 

I have implemented the following when bundling:
- Create `turtle`, `rdf-xml`, and `json-ld` directories in the `ontologies` directory.
- Create `markdown` and `html` directories for `docs/` and `migration/v*/`.
- Create `docs/markdown/models/` and `docs/html/models/`.

This gist bundle contains the changes listed above: [gist14.1.0_webDownload.zip](https://github.com/user-attachments/files/23537259/gist14.1.0_webDownload.zip)

This screenshot is from the gist bundle (above) showing the changes:
<img width="501" height="889" alt="Image" src="https://github.com/user-attachments/assets/b5c6f771-7bcf-4e29-88f5-eab244cdc06c" />
