### PR TITLE
Refactor pre-commit hook, always use latest version

### DIFF
--- a/docs/release_notes/891-refactor-pre-commit
+++ b/docs/release_notes/891-refactor-pre-commit
@@ -1,5 +1,5 @@
 ### Patch Updates
-- Refactored the git pre-commit to make sure the latest version is always used. Issue [#891](https://github.com/semanticarts/gist/issues/891)
-  - Renamed `tools/pre-commit` to `tools/pre-commit-code`
-  - New file `tools/pre-commit-hook` which just calls `./tools/pre-commit-code`.
-  - Updated setup.cmd to install `tools/pre-commit-hook` as `.git/hooks/pre-commit`
+- Refactored the git pre-commit to make sure the latest version is always used. Issue [#891](https://github.com/semanticarts/gist/issues/891).
+  - Renamed `tools/pre-commit` to `tools/pre-commit-code`.
+  - Added new file `tools/pre-commit-hook` which just calls `./tools/pre-commit-code`.
+  - Updated `setup.cmd` to install `tools/pre-commit-hook` as `.git/hooks/pre-commit`.

--- a/docs/release_notes/891-refactor-pre-commit
+++ b/docs/release_notes/891-refactor-pre-commit
@@ -1,0 +1,5 @@
+### Patch Updates
+- Refactored the git pre-commit to make sure the latest version is always used. Issue [#891](https://github.com/semanticarts/gist/issues/891)
+  - Renamed `tools/pre-commit` to `tools/pre-commit-code`
+  - New file `tools/pre-commit-hook` which just calls `./tools/pre-commit-code`.
+  - Updated setup.cmd to install `tools/pre-commit-hook` as `.git/hooks/pre-commit`

--- a/tools/pre-commit-code
+++ b/tools/pre-commit-code
@@ -1,6 +1,7 @@
 #!/usr/bin/env sh
 
-# This file should be copied into the .git/hooks directory of the project.
+# This file performs all the actual git pre-commit checks.
+# It should be called by .git/hooks/pre-commit, which should be a copy of tools/pre-commit-hook.
 
 # Stops accidental commits to branches master, main, or develop.
 BRANCH=`git rev-parse --abbrev-ref HEAD`

--- a/tools/pre-commit-hook
+++ b/tools/pre-commit-hook
@@ -1,0 +1,18 @@
+#!/usr/bin/env sh
+
+# This file should be copied into the .git/hooks directory of the project.
+# All it does is call ./tools/pre-commit-code
+
+# Get root directory of this git repository
+base_dir=$(git rev-parse --show-toplevel)
+
+# Run the pre-commit code from the ./tools/ directory
+"${base_dir}/tools/pre-commit-code"
+rc=$?
+
+# Return the response code from previous command
+if [ ! ${rc} -eq 0 ] ; then
+  exit 1
+fi
+
+exit 0

--- a/tools/pre-commit-hook
+++ b/tools/pre-commit-hook
@@ -1,7 +1,8 @@
 #!/usr/bin/env sh
 
 # This file should be copied into the .git/hooks directory of the project.
-# All it does is call ./tools/pre-commit-code
+# When the setup.cmd script is executed it will make the copy for you.
+# All this script does is call ./tools/pre-commit-code.
 
 # Get root directory of this git repository.
 base_dir=$(git rev-parse --show-toplevel)

--- a/tools/pre-commit-hook
+++ b/tools/pre-commit-hook
@@ -3,14 +3,14 @@
 # This file should be copied into the .git/hooks directory of the project.
 # All it does is call ./tools/pre-commit-code
 
-# Get root directory of this git repository
+# Get root directory of this git repository.
 base_dir=$(git rev-parse --show-toplevel)
 
-# Run the pre-commit code from the ./tools/ directory
+# Run the pre-commit code from the ./tools/ directory.
 "${base_dir}/tools/pre-commit-code"
 rc=$?
 
-# Return the response code from previous command
+# Return the response code from previous command.
 if [ ! ${rc} -eq 0 ] ; then
   exit 1
 fi

--- a/tools/setup.cmd
+++ b/tools/setup.cmd
@@ -16,16 +16,19 @@ base_dir=$(git rev-parse --show-toplevel)
 # Print out commands so user can see what is being done
 set -x
 
-# Copy pre-commit to the git hooks directory
-cp "${base_dir}/tools/pre-commit" "${base_dir}/.git/hooks/"
+# Copy pre-commit-hook to the git hooks directory
+cp "${base_dir}/tools/pre-commit-hook" "${base_dir}/.git/hooks/pre-commit"
 
-# Make pre-commit hook executable. 
+# Make pre-commit hook executable.
 chmod +x "${base_dir}/.git/hooks/pre-commit"
+
+# Ensure that tools/pre-commit-code is executable.
+chmod +x "${base_dir}/tools/pre-commit-code"
 
 # Ensure that the serializer pre-commit hook is executable.
 chmod +x "${base_dir}/tools/serializer/pre-commit"
 
-# Don't track executable flags on files in this repository (this is not a global setting). 
+# Don't track executable flags on files in this repository (this is not a global setting).
 git config core.filemode false
 
 # Exit linux shell
@@ -35,8 +38,8 @@ exit
 :WINDOWS
 CHDIR "%~dp0"
 IF EXIST "tools" chdir tools
-IF EXIST "pre-commit" (
-  copy "pre-commit" ..\.git\hooks\
+IF EXIST "pre-commit-hook" (
+  copy "pre-commit-hook" ..\.git\hooks\pre-commit
 ) ELSE (
-  echo Could not find the "pre-commit" file in %cd%.
+  echo ERROR: Could not find the "pre-commit-hook" file in %cd%.
 )

--- a/tools/setup.cmd
+++ b/tools/setup.cmd
@@ -3,20 +3,20 @@
 : # Be careful trying to modify it unless you understand how it really works.
 
 : # Currently, this is very minimal:
-: # - install a git pre-commit hook to enforce certain expectations prior to making a commit
+: # - Install a git pre-commit hook to enforce certain expectations prior to making a commit.
 
 :; if [ -z 0 ]; then
   @echo off
   goto :WINDOWS
 fi
 
-# Get root directory of this git repository
+# Get root directory of this git repository.
 base_dir=$(git rev-parse --show-toplevel)
 
-# Print out commands so user can see what is being done
+# Print out commands so user can see what is being done.
 set -x
 
-# Copy pre-commit-hook to the git hooks directory
+# Copy pre-commit-hook to the git hooks directory.
 cp "${base_dir}/tools/pre-commit-hook" "${base_dir}/.git/hooks/pre-commit"
 
 # Make pre-commit hook executable.
@@ -31,7 +31,7 @@ chmod +x "${base_dir}/tools/serializer/pre-commit"
 # Don't track executable flags on files in this repository (this is not a global setting).
 git config core.filemode false
 
-# Exit linux shell
+# Exit linux shell.
 exit
 
 


### PR DESCRIPTION
Closes https://github.com/semanticarts/gist/issues/891

This moves all of the pre-commit logic into a separate file which is called by the new pre-commit hook.
This means that changes in the pre-commit-code file will automatically be used in the future as we make changes.