### PR TITLE
Rewrote gist:Event disjointness assertions so that subject is alphabetically prior to object per previous practice.

### DIFF
--- a/docs/release_notes/1364-alphabatize-gistEvent-disjointness-assertions.md
+++ b/docs/release_notes/1364-alphabatize-gistEvent-disjointness-assertions.md
@@ -1,3 +1,3 @@
 ### Patch Updates
 
-- Rewrote `gist:Event` disjointness assertions to that subject is alphabetically prior to object per previous practice. Issue [#1364](https://github.com/semanticarts/gist/issues/1364).
+- Rewrote `gist:Event` disjointness assertions so that subject is alphabetically prior to object per previous practice. Issue [#1364](https://github.com/semanticarts/gist/issues/1364).

--- a/docs/release_notes/1364-alphabatize-gistEvent-disjointness-assertions.md
+++ b/docs/release_notes/1364-alphabatize-gistEvent-disjointness-assertions.md
@@ -1,0 +1,3 @@
+### Patch Updates
+
+- Rewrote `gist:Event` disjointness assertions to that subject is alphabetically prior to object per previous practice. Issue [#1364](https://github.com/semanticarts/gist/issues/1364).

--- a/ontologies/gistCore.ttl
+++ b/ontologies/gistCore.ttl
@@ -189,6 +189,7 @@ gist:Agreement
 
 gist:Aspect
 	a owl:Class ;
+	owl:disjointWith gist:Event ;
 	skos:definition "A measurable characteristic."^^xsd:string ;
 	skos:example "Length, weight, cost, cycle time, defect rate."^^xsd:string ;
 	skos:prefLabel "Aspect"^^xsd:string ;
@@ -289,6 +290,7 @@ gist:Category
 			) ;
 		] ;
 	] ;
+	owl:disjointWith gist:Event ;
 	skos:definition "A concept or label used to categorize other instances without specifying any formal semantics."^^xsd:string ;
 	skos:example "Tags used in folksonomies; formal definitions from other systems."^^xsd:string ;
 	skos:prefLabel "Category"^^xsd:string ;
@@ -673,8 +675,6 @@ gist:EquipmentType
 gist:Event
 	a owl:Class ;
 	owl:disjointWith
-		gist:Aspect ,
-		gist:Category ,
 		gist:Language ,
 		gist:Magnitude ,
 		gist:TimeInterval ,


### PR DESCRIPTION
Closes #1364 