### PR TITLE
Updated definition and scope note of gist:System

### DIFF
--- a/docs/release_notes/1288-modify-system-definition.md
+++ b/docs/release_notes/1288-modify-system-definition.md
@@ -1,0 +1,3 @@
+### Minor Updates
+
+- Updated definition of `gist:System` to remove reference to goals. Added scope note that states `gist:System` may be used for either natural or man-made systems. Issue [#1288](https://github.com/semanticarts/gist/issues/1288).

--- a/ontologies/gistCore.ttl
+++ b/ontologies/gistCore.ttl
@@ -1824,7 +1824,7 @@ gist:System
 			]
 		) ;
 	] ;
-	skos:definition "A composite made up of interacting or interdependent component parts that together function as a whole."^^xsd:string ;
+	skos:definition "A composite made up of interacting or interdependent components that together operate as a whole."^^xsd:string ;
 	skos:prefLabel "System"^^xsd:string ;
 	skos:scopeNote "May be used to refer to either man-made or natural systems."^^xsd:string ;
 	.

--- a/ontologies/gistCore.ttl
+++ b/ontologies/gistCore.ttl
@@ -1825,6 +1825,7 @@ gist:System
 		) ;
 	] ;
 	skos:definition "A composite made up of interacting or interdependent components that together operate as a whole."^^xsd:string ;
+	skos:example "A manufacturing system, a storm system."^^xsd:string ;
 	skos:prefLabel "System"^^xsd:string ;
 	skos:scopeNote "May be used to refer to either man-made or natural systems."^^xsd:string ;
 	.

--- a/ontologies/gistCore.ttl
+++ b/ontologies/gistCore.ttl
@@ -1277,16 +1277,6 @@ gist:Offer
 			gist:ContingentObligation
 			[
 				a owl:Restriction ;
-				owl:onProperty gist:offersToProvide ;
-				owl:someValuesFrom owl:Thing ;
-			]
-			[
-				a owl:Restriction ;
-				owl:onProperty gist:offersToReceive ;
-				owl:someValuesFrom owl:Thing ;
-			]
-			[
-				a owl:Restriction ;
 				owl:onProperty gist:hasGiver ;
 				owl:someValuesFrom [
 					a owl:Class ;
@@ -1295,6 +1285,16 @@ gist:Offer
 						gist:Person
 					) ;
 				] ;
+			]
+			[
+				a owl:Restriction ;
+				owl:onProperty gist:offersToProvide ;
+				owl:someValuesFrom owl:Thing ;
+			]
+			[
+				a owl:Restriction ;
+				owl:onProperty gist:offersToReceive ;
+				owl:someValuesFrom owl:Thing ;
 			]
 			[
 				a owl:Restriction ;
@@ -1824,8 +1824,9 @@ gist:System
 			]
 		) ;
 	] ;
-	skos:definition "A composite with component parts that contribute to the goal of the system."^^xsd:string ;
+	skos:definition "A composite made up of component parts."^^xsd:string ;
 	skos:prefLabel "System"^^xsd:string ;
+	skos:scopeNote "May be used to refer to either man-made or natural systems."^^xsd:string ;
 	.
 
 gist:Tag

--- a/ontologies/gistCore.ttl
+++ b/ontologies/gistCore.ttl
@@ -1824,7 +1824,7 @@ gist:System
 			]
 		) ;
 	] ;
-	skos:definition "A composite made up of component parts."^^xsd:string ;
+	skos:definition "A composite made up of interacting or interdependent component parts that together function as a whole."^^xsd:string ;
 	skos:prefLabel "System"^^xsd:string ;
 	skos:scopeNote "May be used to refer to either man-made or natural systems."^^xsd:string ;
 	.


### PR DESCRIPTION
Closes #1288 

Removes reference to goals from the definition of `gist:System`. Adds scope note that clarifies that `gist:System` may be used for either man-made or natural systems. 