### PR TITLE
Deprecate gist:Language

### DIFF
--- a/docs/release_notes/1379-deprecate-gist-language.md
+++ b/docs/release_notes/1379-deprecate-gist-language.md
@@ -1,0 +1,3 @@
+### Major Updates
+
+- Deprecated class `gist:Language`. Issue [#1379](https://github.com/semanticarts/gist/issues/1379).

--- a/ontologies/gistCore.ttl
+++ b/ontologies/gistCore.ttl
@@ -1058,6 +1058,7 @@ gist:Landmark
 
 gist:Language
 	a owl:Class ;
+	owl:deprecated "true"^^xsd:boolean ;
 	owl:disjointWith
 		gist:Magnitude ,
 		gist:Organization ,


### PR DESCRIPTION
Deprecates class `gist:Language`. Issue [#1379](https://github.com/semanticarts/gist/issues/1379)