### PR TITLE
Delete/Deprecate gist:Building

### DIFF
--- a/docs/release_notes/1205-delete-gist-building
+++ b/docs/release_notes/1205-delete-gist-building
@@ -1,0 +1,8 @@
+## Major Updates
+
+- Deprecated classes `gist:Landmark` and `gist:Building`. Issue [#1205](https://github.com/semanticarts/gist/issues/1205).
+
+## Minor Updates
+
+- Changed examples of `gist:PhysicalIdentifiableItem` to include a landmark and building.
+- Modified existing examples of `gist:PhysicalIdentifiableItem` to be more specific.

--- a/docs/release_notes/1205-delete-gist-building
+++ b/docs/release_notes/1205-delete-gist-building
@@ -4,5 +4,4 @@
 
 ## Minor Updates
 
-- Changed examples of `gist:PhysicalIdentifiableItem` to include a landmark and building.
-- Modified existing examples of `gist:PhysicalIdentifiableItem` to be more specific.
+- Updated examples of `gist:PhysicalIdentifiableItem`.

--- a/ontologies/gistCore.ttl
+++ b/ontologies/gistCore.ttl
@@ -239,6 +239,7 @@ gist:Behavior
 gist:Building
 	a owl:Class ;
 	rdfs:subClassOf gist:Landmark ;
+	owl:deprecated "true"^^xsd:boolean ;
 	skos:definition "A relatively permanent man-made structure situated on a plot of land, having a roof and walls, commonly used for dwelling, entertaining, or working."^^xsd:string ;
 	skos:example
 		"A house, school, store, factory, chicken coop."^^xsd:string ,
@@ -1051,6 +1052,7 @@ gist:Landmark
 			] ;
 		]
 		;
+	owl:deprecated "true"^^xsd:boolean ;
 	skos:definition "Something permanently attached to the Earth."^^xsd:string ;
 	skos:editorialNote "See guidance on removing the term in the next major release at https://github.com/semanticarts/gist/issues/947#issuecomment-1679566885."^^xsd:string ;
 	skos:prefLabel "Landmark"^^xsd:string ;
@@ -1563,7 +1565,7 @@ gist:PhysicalIdentifiableItem
 		gist:UnitOfMeasure
 		;
 	skos:definition "A discrete physical object which, if subdivided, will result in parts that are distinguishable in nature from the whole and in general also from the other parts."^^xsd:string ;
-	skos:example "A computer, a book, a car."^^xsd:string ;
+	skos:example "A laptop, a physical book, a car, a building, a landmark."^^xsd:string ;
 	skos:prefLabel "Physical Identifiable Item"^^xsd:string ;
 	skos:scopeNote "This concept generally corresponds to count nouns in English. By contrast, physical substances, such as an amount of water, flour, or sand, are mass nouns. Physical identifiable items are made up of physical substances; e.g., a cake is made up of butter, flour, and sugar; a statue is made of bronze. If you divide a physical substance such as an amount of water into parts, you have two amounts of water otherwise indistinguishable from one another; if you divide a physical identifiable item such as a computer into parts, each part is different from the whole."^^xsd:string ;
 	.

--- a/ontologies/gistCore.ttl
+++ b/ontologies/gistCore.ttl
@@ -1565,7 +1565,7 @@ gist:PhysicalIdentifiableItem
 		gist:UnitOfMeasure
 		;
 	skos:definition "A discrete physical object which, if subdivided, will result in parts that are distinguishable in nature from the whole and in general also from the other parts."^^xsd:string ;
-	skos:example "A laptop, a physical book, a car, a building, a landmark."^^xsd:string ;
+	skos:example "A laptop, a physical book, a car, a building, a landmark (such as a tree stump with an etched marking to denote a campsite)."^^xsd:string ;
 	skos:prefLabel "Physical Identifiable Item"^^xsd:string ;
 	skos:scopeNote "This concept generally corresponds to count nouns in English. By contrast, physical substances, such as an amount of water, flour, or sand, are mass nouns. Physical identifiable items are made up of physical substances; e.g., a cake is made up of butter, flour, and sugar; a statue is made of bronze. If you divide a physical substance such as an amount of water into parts, you have two amounts of water otherwise indistinguishable from one another; if you divide a physical identifiable item such as a computer into parts, each part is different from the whole."^^xsd:string ;
 	.


### PR DESCRIPTION
## Major Updates

- Deprecated classes `gist:Landmark` and `gist:Building`. Issue [#1205](https://github.com/semanticarts/gist/issues/1205).

## Minor Updates

- Changed examples of `gist:PhysicalIdentifiableItem` to include a landmark and building. Issue [#1205](https://github.com/semanticarts/gist/issues/1205).
- Modified existing examples of `gist:PhysicalIdentifiableItem` to be more specific. Issue [#1205](https://github.com/semanticarts/gist/issues/1205).
