### PR TITLE
Fixed links in markdown and HTML during bundling process

### DIFF
--- a/bundle.yaml
+++ b/bundle.yaml
@@ -67,28 +67,28 @@ tools:
     - "-t"
     - "{outputFile}"
 actions:
-- action: "verify"
-  message: "Validating ontology via SHACL."
-  type: "shacl"
-  inference: "none"
-  source: "{input}/ontologies"
-  includes:
-    - "*.ttl"
-  shapes:
-    source: "{input}/validation/shapes/ontologyShapes.ttl"
-- action: "verify"
-  message: "Validating ontology via queries."
-  type: "construct"
-  inference: "none"
-  source: "{input}/ontologies"
-  includes:
-    - gistCore.ttl
-  stopOnFail: false
-  target: "{input}/validation"
-  queries:
-    source: "{input}/validation/queries"
-    includes:
-      - "*_construct.rq"
+# - action: "verify"
+#   message: "Validating ontology via SHACL."
+#   type: "shacl"
+#   inference: "none"
+#   source: "{input}/ontologies"
+#   includes:
+#     - "*.ttl"
+#   shapes:
+#     source: "{input}/validation/shapes/ontologyShapes.ttl"
+# - action: "verify"
+#   message: "Validating ontology via queries."
+#   type: "construct"
+#   inference: "none"
+#   source: "{input}/ontologies"
+#   includes:
+#     - gistCore.ttl
+#   stopOnFail: false
+#   target: "{input}/validation"
+#   queries:
+#     source: "{input}/validation/queries"
+#     includes:
+#       - "*_construct.rq"
 - action: "mkdir"
   directory: "{output}"
 - action: "copy"
@@ -209,6 +209,24 @@ actions:
   includes:
     - "README.md"
     - "gist-logo.png"
+- action: "move"
+  message: "Replace /docs/ with ./ in markdown files."
+  source: "{output}/docs/"
+  target: "{output}/docs/"
+  includes:
+    - "*.md"
+  replace:
+    from: "docs/"
+    to: "./"
+- action: "move"
+  message: "Correct gist logo local link."
+  source: "{output}/docs/"
+  target: "{output}/docs/"
+  includes:
+    - "README.md"
+  replace:
+    from: "\\./gist-logo.png"
+    to: "../gist-logo.png"
 - action: "markdown"
   message: "Formatting documentation as HTML."
   source: "{output}/docs/"

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -236,6 +236,15 @@ actions:
   replace:
     from: "\\.\\./docs/"
     to: "./"
+- action: "move"
+  message: "Replace '../migration/' with '../../migration/' in ReleaseNotes."
+  source: "{output}/docs/"
+  target: "{output}/docs/"
+  includes:
+    - "ReleaseNotes.md"
+  replace:
+    from: "\\.\\./migration/"
+    to: "../../migration/"
 - action: "markdown"
   message: "Formatting documentation as HTML."
   source: "{output}/docs/"

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -67,28 +67,28 @@ tools:
     - "-t"
     - "{outputFile}"
 actions:
-# - action: "verify"
-#   message: "Validating ontology via SHACL."
-#   type: "shacl"
-#   inference: "none"
-#   source: "{input}/ontologies"
-#   includes:
-#     - "*.ttl"
-#   shapes:
-#     source: "{input}/validation/shapes/ontologyShapes.ttl"
-# - action: "verify"
-#   message: "Validating ontology via queries."
-#   type: "construct"
-#   inference: "none"
-#   source: "{input}/ontologies"
-#   includes:
-#     - gistCore.ttl
-#   stopOnFail: false
-#   target: "{input}/validation"
-#   queries:
-#     source: "{input}/validation/queries"
-#     includes:
-#       - "*_construct.rq"
+- action: "verify"
+  message: "Validating ontology via SHACL."
+  type: "shacl"
+  inference: "none"
+  source: "{input}/ontologies"
+  includes:
+    - "*.ttl"
+  shapes:
+    source: "{input}/validation/shapes/ontologyShapes.ttl"
+- action: "verify"
+  message: "Validating ontology via queries."
+  type: "construct"
+  inference: "none"
+  source: "{input}/ontologies"
+  includes:
+    - gistCore.ttl
+  stopOnFail: false
+  target: "{input}/validation"
+  queries:
+    source: "{input}/validation/queries"
+    includes:
+      - "*_construct.rq"
 - action: "mkdir"
   directory: "{output}"
 - action: "copy"

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -210,16 +210,16 @@ actions:
     - "README.md"
     - "gist-logo.png"
 - action: "move"
-  message: "Replace /docs/ with ./ in markdown files."
+  message: "Replace 'docs/' with './' in README."
   source: "{output}/docs/"
   target: "{output}/docs/"
   includes:
-    - "*.md"
+    - "README.md"
   replace:
     from: "docs/"
     to: "./"
 - action: "move"
-  message: "Correct gist logo local link."
+  message: "Correct gist logo local link in README."
   source: "{output}/docs/"
   target: "{output}/docs/"
   includes:
@@ -227,6 +227,15 @@ actions:
   replace:
     from: "\\./gist-logo.png"
     to: "../gist-logo.png"
+- action: "move"
+  message: "Replace '../docs/' with './' in ReleaseNotes."
+  source: "{output}/docs/"
+  target: "{output}/docs/"
+  includes:
+    - "ReleaseNotes.md"
+  replace:
+    from: "\\.\\./docs/"
+    to: "./"
 - action: "markdown"
   message: "Formatting documentation as HTML."
   source: "{output}/docs/"


### PR DESCRIPTION
## Changes currently in this PR

> Note: The following diffs were before the changes to the README in https://github.com/semanticarts/gist/pull/1440. 

Changes in bundled README (old bundled vs new bundled README):
```
➜  gist git:(hotfix/fixing-links-in-documentation) diff gist14.1.0_webDownload/docs/markdown/README.md gist14.1.1_webDownload/docs/markdown/README.md
1c1
< ![gist logo](./gist-logo.png)
---
> ![gist logo](../gist-logo.png)
22c22
< You can also contribute to gist by adding your comments to [issue discussion threads](https://github.com/semanticarts/gist/issues) and submitting new issues and pull requests (see [guidelines for contributions](docs/Contributing.md)). You can view [minutes](https://github.com/semanticarts/gist/wiki/gist-Development-Team-Meeting-Notes) from our bi-monthly review sessions to find out what we've been discussing and get a preview of upcoming changes to gist.
---
> You can also contribute to gist by adding your comments to [issue discussion threads](https://github.com/semanticarts/gist/issues) and submitting new issues and pull requests (see [guidelines for contributions](./Contributing.md)). You can view [minutes](https://github.com/semanticarts/gist/wiki/gist-Development-Team-Meeting-Notes) from our bi-monthly review sessions to find out what we've been discussing and get a preview of upcoming changes to gist.
79c79
< For major version upgrades, migration guides with SPARQL queries are provided in the [`migration/`](migration/) directory. See also [Major Version Migration](docs/MajorVersionMigration.md) for guidance on the upgrade process.
---
> For major version upgrades, migration guides with SPARQL queries are provided in the [`migration/`](migration/) directory. See also [Major Version Migration](./MajorVersionMigration.md) for guidance on the upgrade process.
81c81
< For full details, see [Change and Release Management](docs/ChangeAndReleaseManagement.md) and [Release Notes](docs/ReleaseNotes.md).
---
> For full details, see [Change and Release Management](./ChangeAndReleaseManagement.md) and [Release Notes](./ReleaseNotes.md).
103c103
< - [Deprecation and Deletion Policy](docs/DeprecationAndDeletionPolicy.md)
---
> - [Deprecation and Deletion Policy](./DeprecationAndDeletionPolicy.md)
```

Changes in bundled ReleaseNotes (old bundled vs new bundled ReleaseNotes):
```
➜  gist git:(hotfix/fixing-links-in-documentation) diff gist14.1.0_webDownload/docs/markdown/ReleaseNotes.md  gist14.1.1_webDownload/docs/markdown/ReleaseNotes.md
45c45
< This is a major release that includes several changes which break compatibility with previous versions of gist. See the [migration guide](./MajorVersionMigration.md) for documentation on updating existing gist-based ontologies and instance data. [Migration scripts and documentation](../migration/v14.0) are provided to facilitate the upgrade process.
---
> This is a major release that includes several changes which break compatibility with previous versions of gist. See the [migration guide](./MajorVersionMigration.md) for documentation on updating existing gist-based ontologies and instance data. [Migration scripts and documentation](../../migration/v14.0) are provided to facilitate the upgrade process.
117c117
< This is a major release that includes several changes which break compatibility with previous versions of gist, most notably an entirely rearchitected model of units of measure and magnitudes and a new address model. See the [migration guide](./MajorVersionMigration.md) for documentation on updating existing gist-based ontologies and instance data. [Migration scripts and documentation](../migration/v13.0) are provided to facilitate the upgrade process.
---
> This is a major release that includes several changes which break compatibility with previous versions of gist, most notably an entirely rearchitected model of units of measure and magnitudes and a new address model. See the [migration guide](./MajorVersionMigration.md) for documentation on updating existing gist-based ontologies and instance data. [Migration scripts and documentation](../../migration/v13.0) are provided to facilitate the upgrade process.
233,234c233,234
< - Added [scripts](../migration/v13.0/queries/uom_queries) for the migration of existing client ontologies and instance data.
< - Added [complete documentation](../docs/models/UnitOfMeasureModel.md) on understanding and implementing the new model.
---
> - Added [scripts](../../migration/v13.0/queries/uom_queries) for the migration of existing client ontologies and instance data.
> - Added [complete documentation](./models/UnitOfMeasureModel.md) on understanding and implementing the new model.
```