### PR TITLE
Corrected migration link in README when bundling

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ gist follows [Semantic Versioning](https://semver.org/), adapted for ontology de
 
 A minor or patch upgrade should require only updating the version number in your import statement.
 
-For major version upgrades, migration guides with SPARQL queries are provided in the [`migration/`](migration/) directory. See also [Major Version Migration](docs/MajorVersionMigration.md) for guidance on the upgrade process.
+For major version upgrades, migration guides with SPARQL queries are provided in the [`migration/`](./migration/) directory. See also [Major Version Migration](docs/MajorVersionMigration.md) for guidance on the upgrade process.
 
 ## gist Documentation
 

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -228,6 +228,15 @@ actions:
     from: "\\./gist-logo.png"
     to: "../gist-logo.png"
 - action: "move"
+  message: "Replace './migration/' with '../migration/' in README."
+  source: "{output}/docs/"
+  target: "{output}/docs/"
+  includes:
+    - "README.md"
+  replace:
+    from: "\\./migration/"
+    to: "../../migration/"
+- action: "move"
   message: "Replace '../docs/' with './' in ReleaseNotes."
   source: "{output}/docs/"
   target: "{output}/docs/"


### PR DESCRIPTION
This PR corrects the migration link in README.md when bundling. I tested the links in #1441 but missed migration because it is in a codeblock so it does not appear as a link:
<img width="1337" height="315" alt="image" src="https://github.com/user-attachments/assets/a32eae97-0cca-4fde-96c9-3b3ea834bce3" />

Here is the diff between the old generated (bundled) README and the new:
```
➜  gist git:(hotfix/fixing-migration-link-in-release-notes) diff gist14.1.0_webDownload/docs/markdown/README.md gist14.1.1_webDownload/docs/markdown/README.md        
79c79
< For major version upgrades, migration guides with SPARQL queries are provided in the [`migration/`](migration/) directory. See also [Major Version Migration](./MajorVersionMigration.md) for guidance on the upgrade process.
---
> For major version upgrades, migration guides with SPARQL queries are provided in the [`migration/`](../../migration/) directory. See also [Major Version Migration](./MajorVersionMigration.md) for guidance on the upgrade process.
```

Clicking the migration link in the HTML brings you here:
<img width="1095" height="347" alt="Screenshot 2026-04-16 at 3 40 42 PM" src="https://github.com/user-attachments/assets/e431b8ba-ae45-436b-bea0-fd0dcb5b7adb" />

Clicking the migration link in the markdown in VSCode will highlight the migration directory in the bundled directory.

I also updated the link in the README adding `./` before `migration/`. This makes it easier for me to replace in the bundler and visually identify when looking at the raw markdown. 