### PR TITLE
Add rdfs:range gist:GeoLocation to gist:occursIn and release note

### DIFF
--- a/docs/release_notes/occursIn_range_geolocation.md
+++ b/docs/release_notes/occursIn_range_geolocation.md
@@ -1,0 +1,3 @@
+### Patch Updates
+
+- Added `rdfs:range gist:GeoLocation` to `gist:occursIn` for explicit range semantics.

--- a/ontologies/gistCore.ttl
+++ b/ontologies/gistCore.ttl
@@ -3150,6 +3150,7 @@ gist:numericValue
 
 gist:occursIn
 	a owl:ObjectProperty ;
+	rdfs:range gist:GeoLocation ;
 	skos:definition "Relates something, such as an event, to the geographic location where it did, does, or will happen."^^xsd:string ;
 	skos:prefLabel "occurs in"^^xsd:string ;
 	.


### PR DESCRIPTION
### Motivation
- The reviewer requested a strict range for `gist:occursIn` (Option A) to make the ontology semantics explicit and because `gist:Place` has been replaced by `gist:GeoLocation` in the model. 

### Description
- Added `rdfs:range gist:GeoLocation` to the `gist:occursIn` property in `ontologies/gistCore.ttl` and created a release note file `docs/release_notes/occursIn_range_geolocation.md` describing the change. 

### Testing
- Ran repository checks and verification commands (`git diff`, `nl` to inspect file regions, `rg` to locate terms, and `git status`/`git commit`) to confirm the TTL change and the release note file were added, and all commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a07803ab22883318396f42ad8c59935)