### PR TITLE
Add rdfs:range gist:GeoLocation to gist:occursIn

### DIFF
--- a/docs/release_notes/1016-occursIn_range_geolocation.md
+++ b/docs/release_notes/1016-occursIn_range_geolocation.md
@@ -1,3 +1,3 @@
-### Patch Updates
+### Major Updates
 
 - Added `rdfs:range gist:GeoLocation` to `gist:occursIn`. Issue [#1016](https://github.com/semanticarts/gist/issues/1016).

--- a/docs/release_notes/1016-occursIn_range_geolocation.md
+++ b/docs/release_notes/1016-occursIn_range_geolocation.md
@@ -1,0 +1,3 @@
+### Patch Updates
+
+- Added `rdfs:range gist:GeoLocation` to `gist:occursIn`. Issue [#1016](https://github.com/semanticarts/gist/issues/1016).

--- a/ontologies/gistCore.ttl
+++ b/ontologies/gistCore.ttl
@@ -3150,6 +3150,7 @@ gist:numericValue
 
 gist:occursIn
 	a owl:ObjectProperty ;
+	rdfs:range gist:GeoLocation ;
 	skos:definition "Relates something, such as an event, to the geographic location where it did, does, or will happen."^^xsd:string ;
 	skos:prefLabel "occurs in"^^xsd:string ;
 	.


### PR DESCRIPTION
## Summary

- Added `rdfs:range gist:GeoLocation` to `gist:occursIn` in `gistCore.ttl`.
- Added release note.

Fixes #1016

## Test plan

- [x] Verify `gist:occursIn` block in `ontologies/gistCore.ttl` includes `rdfs:range gist:GeoLocation`.
- [x] Verify release note at `docs/release_notes/1016-occursIn_range_geolocation.md` is present and correctly formatted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)