### PR TITLE
Edit bundle.yaml to fix links within v14 migration docs

### DIFF
--- a/bundle.yaml
+++ b/bundle.yaml
@@ -378,13 +378,13 @@ actions:
   target: "{output}/migration/v14.0/html-doc/"
   includes:
     - "*.html"
+  # Replace .md with .html in local links of HTML files
+  replace:
+    from: "((\\./|(?:\\.\\./)+).+)\\.md"
+    to: "\\g<1>.html"
 - action: "move"
   source: "{output}/migration/v14.0/"
   target: "{output}/migration/v14.0/markdown-doc/"
   includes:
     - "*.md"
-  # Replace .md with .html in local links of HTML files
-  replace:
-    from: "((\\./|(?:\\.\\./)+).+)\\.md"
-    to: "\\g<1>.html"
 

--- a/docs/release_notes/1467-bundle-yaml-fix-for-v14-migration-docs.md
+++ b/docs/release_notes/1467-bundle-yaml-fix-for-v14-migration-docs.md
@@ -1,0 +1,3 @@
+### Minor Updates
+
+- Fixed bug in bundle.yaml affecting links within v14 migration documents. Issue [#1467](https://github.com/semanticarts/gist/issues/1467).


### PR DESCRIPTION
Closes #1467 

move a code block within bundle.yaml