### PR TITLE
add class equivalence to contract term

### DIFF
--- a/docs/release_notes/1354-ContractTerm
+++ b/docs/release_notes/1354-ContractTerm
@@ -1,0 +1,5 @@
+### Minor Updates
+
+- Added class equivalence to `gist:ContractTerm`. Issue [#1354](https://github.com/semanticarts/gist/issues/1354).
+- Simplified definition of `gist:ContractTerm`. Issue [#1354](https://github.com/semanticarts/gist/issues/1354).
+

--- a/ontologies/gistCore.ttl
+++ b/ontologies/gistCore.ttl
@@ -1,3 +1,4 @@
+@prefix : <https://w3id.org/semanticarts/ontology/gistCore#> .
 @prefix gist: <https://w3id.org/semanticarts/ns/ontology/gist/> .
 @prefix gistd: <https://w3id.org/semanticarts/ns/data/gist/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
@@ -511,7 +512,18 @@ gist:Contract
 gist:ContractTerm
 	a owl:Class ;
 	rdfs:subClassOf gist:Specification ;
-	skos:definition "A specification of some aspect of a contract."^^xsd:string ;
+	owl:equivalentClass [
+		a owl:Class ;
+		owl:intersectionOf (
+			gist:Specification
+			[
+				a owl:Restriction ;
+				owl:onProperty gist:isPartOf ;
+				owl:someValuesFrom gist:Contract ;
+			]
+		) ;
+	] ;
+	skos:definition "A specification that is part of a contract."^^xsd:string ;
 	skos:prefLabel "Contract Term"^^xsd:string ;
 	.
 


### PR DESCRIPTION
Closes #1354

Simplified definition to "A specification that is part of a contract."

Added class equivalence: Specification and (isPartOf some Contract)